### PR TITLE
Port ARC: Common components of the ARC Demo and a fix for hardware stack checking

### DIFF
--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc.h
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc.h
@@ -1,0 +1,103 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_CORE_COMM
+ * \brief  header file including common core definitions
+ */
+
+/**
+ * \addtogroup ARC_HAL_CORE_COMM
+ * @{
+ */
+
+#ifndef _ARC_HAL_CORE_H_
+#define _ARC_HAL_CORE_H_
+
+#include "arc_feature_config.h"
+
+#define AUX_BCR_TIMERS                  (0x75)                      /*!< build configuration for processor timers */
+#define AUX_STATUS32                    (0xa)
+#define AUX_STATUS_BIT_AE               (5)                         /*!< processor is in an exception */
+#define AUX_STATUS_BIT_IE               (31)                        /*!< interrupt enable */
+#define AUX_STATUS_BIT_HALT             (0)                         /*!< halt bit */
+#define AUX_STATUS_BIT_SC               (14)                        /*!< stack check bit */
+#define AUX_STATUS_BIT_US               (20)                        /*!< user sleep mode enable bit */
+#define AUX_STATUS_MASK_IE              (1 << AUX_STATUS_BIT_IE)    /*!< mask of AUX_STATUS_BIT_IE */
+#define AUX_STATUS_MASK_HALT            (1 << AUX_STATUS_BIT_HALT)  /*!< mask of AUX_STATUS_BIT_HALT */
+#define AUX_STATUS_MASK_US              (1 << AUX_STATUS_BIT_US)    /*!< mask of AUX_STATUS_BIT_US */
+#define STATUS32_RESET_VALUE            (AUX_STATUS_MASK_US)
+#define AUX_LP_START                    (0x2)                       /*!< loop start address (32-bit) */
+#define AUX_LP_END                      (0x3)                       /*!< loop end address (32-bit) */
+#define AUX_KSTACK_TOP                  (0x264)
+#define AUX_KSTACK_BASE                 (0x265)
+#define AUX_TIMER0_CNT                  (0x21)                      /*!< timer 0 count value */
+#define AUX_TIMER0_CTRL                 (0x22)                      /*!< timer 0 control value */
+#define AUX_TIMER0_LIMIT                (0x23)                      /*!< timer 0 limit value */
+#define AUX_TIMER1_CNT                  (0x100)                     /*!< timer 1 count value */
+#define AUX_TIMER1_CTRL                 (0x101)                     /*!< timer 1 control value */
+#define AUX_TIMER1_LIMIT                (0x102)                     /*!< timer 1 limit value */
+#define AUX_RTC_CTRL                    (0x103)                     /*!< RTC control value */
+#define AUX_RTC_LOW                     (0x104)                     /*!< RTC count low value */
+#define AUX_RTC_HIGH                    (0x105)                     /*!< RTC count high value */
+#define AUX_SECURE_TIMER0_CNT           (0x106)                     /*!< secure timer 0 count value */
+#define AUX_SECURE_TIMER0_CTRL          (0x107)                     /*!< secure timer 0 control value */
+#define AUX_SECURE_TIMER0_LIMIT         (0x108)                     /*!< secure timer 0 limit value */
+#define AUX_SECURE_TIMER1_CNT           (0x109)                     /*!< secure timer 1 count value */
+#define AUX_SECURE_TIMER1_CTRL          (0x10a)                     /*!< secure timer 1 control value */
+#define AUX_SECURE_TIMER1_LIMIT         (0x10b)                     /*!< secure timer 1 limit value */
+#define AUX_ERRET                       (0x400)                     /*!< exception return address */
+#define AUX_ERBTA                       (0x401)                     /*!< BTA saved on exception entry */
+#define AUX_ERSTATUS                    (0x402)                     /*!< STATUS32 saved on exception */
+#define AUX_ECR                         (0x403)                     /*!< exception cause register */
+#define AUX_IRQ_CTRL                    (0xe)                       /*!< interrupt context saving control register */
+#define AUX_INT_VECT_BASE               (0x25)                      /*!< interrupt vector base register */
+#define AUX_IRQ_ACT                     (0x43)                      /*!< active interrupts register */
+#define AUX_IRQ_CAUSE                   (0x40a)                     /*!< interrupt cause register */
+#define AUX_IRQ_SELECT                  (0x40b)                     /*!< interrupt select register */
+#define AUX_IRQ_PRIORITY                (0x206)                     /*!< interrupt priority register */
+#define AUX_IRQ_ENABLE                  (0x40c)                     /*!< interrupt enable register */
+#define AUX_IRQ_TRIGGER                 (0x40d)                     /*!< interrupt trigger: level or pulse */
+#define AUX_IRQ_HINT                    (0x201)                     /*!< software interrupt trigger */
+
+#ifndef __ASSEMBLY__
+
+#include <stdint.h>     /* C99 standard lib */
+#include <limits.h>     /* C99 standard lib */
+#include <stddef.h>     /* C99 standard lib */
+#include <stdbool.h>    /* C99 standard lib */
+
+#define Inline  static __inline__               /* inline function */
+
+#define Asm     __asm__ volatile                /* inline asm (no optimization) */
+
+#endif  /* __ASSEMBLY__ */
+
+#endif  /* _ARC_HAL_CORE_H_ */
+
+// /**  @} */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_asm_common.h
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_asm_common.h
@@ -1,0 +1,264 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC
+ * \brief common macro definitions for assembly file
+ */
+/** @cond ARC_HAL_ASM_COMMON */
+
+#ifndef _ARC_HAL_ASM_COMMON_H_
+#define _ARC_HAL_ASM_COMMON_H_
+
+#include "arc/arc.h"
+
+#ifdef __ASSEMBLY__
+/* the assembly macro definitions in ARC GNU and MWDT are
+ * different, so need different processing
+ */
+#if defined(__GNU__)
+#define MACRO_ARG(x) \x
+#define ASM_MACRO1(name, arg1) name arg1
+#else
+#define MACRO_ARG(x) x
+#define ASM_MACRO1(name, arg1) name, arg1
+#endif
+
+/* Note on the LD/ST addr modes with addr reg wback
+ *
+ * LD.a same as LD.aw
+ *
+ * LD.a    reg1, [reg2, x]  => Pre Incr
+ *      Eff Addr for load = [reg2 + x]
+ *
+ * LD.ab   reg1, [reg2, x]  => Post Incr
+ *      Eff Addr for load = [reg2]
+ */
+.macro ASM_MACRO1(PUSHAX, aux)
+	lr r10, [MACRO_ARG(aux)]
+	PUSH r10
+.endm
+
+.macro ASM_MACRO1(POPAX, aux)
+	POP r10
+	sr r10, [MACRO_ARG(aux)]
+.endm
+
+/*--------------------------------------------------------------
+ * Helpers to save/restore callee-saved regs:
+ * used by several macros below
+ *-------------------------------------------------------------*/
+.macro SAVE_CALLEE_REGS
+	PUSH	r13
+	PUSH	r14
+	PUSH	r15
+	PUSH	r16
+	PUSH	r17
+	PUSH	r18
+	PUSH	r19
+	PUSH	r20
+	PUSH	r21
+	PUSH	r22
+	PUSH	r23
+	PUSH	r24
+	PUSH	r25
+.endm
+
+.macro RESTORE_CALLEE_REGS
+	POP	r25
+	POP	r24
+	POP	r23
+	POP	r22
+	POP	r21
+	POP	r20
+	POP	r19
+	POP	r18
+	POP	r17
+	POP	r16
+	POP	r15
+	POP	r14
+	POP	r13
+.endm
+
+.macro SAVE_LP_REGS
+	PUSH	r60
+	PUSHAX	AUX_LP_START
+	PUSHAX	AUX_LP_END
+.endm
+
+.macro RESTORE_LP_REGS
+	POPAX	AUX_LP_END
+	POPAX	AUX_LP_START
+	POP	r10
+/* must not use the LP_COUNT register(r60) as the destination of multi-cycle instruction */
+	mov	r60, r10
+
+.endm
+
+/* macro to save r0 to r12 */
+.macro SAVE_R0_TO_R12
+	PUSH	r0
+	PUSH	r1
+	PUSH	r2
+	PUSH	r3
+	PUSH	r4
+	PUSH	r5
+	PUSH	r6
+	PUSH	r7
+	PUSH	r8
+	PUSH	r9
+	PUSH	r10
+	PUSH	r11
+	PUSH	r12
+.endm
+
+/* macro to restore r0 to r12 */
+.macro RESTORE_R0_TO_R12
+	POP	r12
+	POP	r11
+	POP	r10
+	POP	r9
+	POP	r8
+	POP	r7
+	POP	r6
+	POP	r5
+	POP	r4
+	POP	r3
+	POP	r2
+	POP	r1
+	POP	r0
+.endm
+
+/* macro to save all non-caller saved regs */
+.macro SAVE_NONSCRATCH_REGS
+/* caller saved regs are saved by caller function */
+	PUSH	gp
+	PUSH	fp
+	PUSH	blink
+	SAVE_CALLEE_REGS
+.endm
+
+/* macro to restore all non-caller saved regs */
+.macro RESTORE_NONSCRATCH_REGS
+	RESTORE_CALLEE_REGS
+	POP	blink
+	POP	fp
+	POP	gp
+.endm
+
+/* normal interrupt prologue, pc, status and r0-r11 are saved by hardware */
+.macro INTERRUPT_PROLOGUE
+	PUSH	r12
+	PUSH	gp
+	PUSH	fp
+	PUSH	ilink
+	PUSH	r30
+
+	sub	sp, sp, 4 /* skip bta */
+.endm
+
+
+/* normal interrupt epilogue, pc, status and r0-r11 are restored by hardware */
+.macro INTERRUPT_EPILOGUE
+	add	sp, sp, 4 /* skip bta */
+
+	POP	r30
+	POP	ilink
+	POP	fp
+	POP	gp
+	POP	r12
+.endm
+
+/* exception prologue, create the same frame of interrupt manually */
+.macro EXCEPTION_PROLOGUE
+	st.as	r10, [sp, -8]
+	PUSHAX	AUX_ERSTATUS
+	PUSHAX	AUX_ERRET
+
+	SAVE_LP_REGS
+
+	PUSH	blink
+
+	PUSH	r11
+	sub	sp, sp, 4 /* r10 is  pushed before */
+	PUSH	r9
+	PUSH	r8
+	PUSH	r7
+	PUSH	r6
+	PUSH	r5
+	PUSH	r4
+	PUSH	r3
+	PUSH	r2
+	PUSH	r1
+	PUSH	r0
+
+	PUSH	r12
+	PUSH	gp
+	PUSH	fp
+	PUSH	ilink
+	PUSH	r30
+
+	PUSHAX	AUX_ERBTA
+.endm
+
+/* exception epilogue, restore the same frame of interrupt manually */
+.macro EXCEPTION_EPILOGUE
+	POPAX	AUX_ERBTA
+
+	POP	r30
+	POP	ilink
+	POP	fp
+	POP	gp
+	POP	r12
+
+	POP	r0
+	POP	r1
+	POP	r2
+	POP	r3
+	POP	r4
+	POP	r5
+	POP	r6
+	POP	r7
+	POP	r8
+	POP	r9
+	add	sp, sp, 4 /* r10 will be popped finally */
+	POP	r11
+
+	POP	blink
+
+	RESTORE_LP_REGS
+
+	POPAX	AUX_ERRET
+	POPAX	AUX_ERSTATUS
+
+	ld.as	r10, [sp, -8]
+.endm
+
+#endif  /* __ASSEMBLY__ */
+#endif	/* _ARC_HAL_ASM_COMMON_H */
+/** @endcond */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_builtin.h
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_builtin.h
@@ -1,0 +1,101 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_BUILTIN
+ * @brief Header file of builtin and helper functions
+ *
+ * The Metaware toolchain and the GNU toolchain are supported. The details please go to see the file.
+ */
+
+/**
+ * @addtogroup	ARC_HAL_BUILTIN
+ * @{
+ */
+
+#ifndef _ARC_HAL_BUILTIN_H_
+#define _ARC_HAL_BUILTIN_H_
+
+#include "arc/arc.h"
+
+#ifndef __ASSEMBLY__
+
+#if defined(__CCAC__)
+
+#define arc_aux_read(reg) _lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) _sr((unsigned int)val, (volatile uint32_t)reg)
+
+#else /* ! __CCAC__ */
+
+#define arc_aux_read(reg) __builtin_arc_lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) __builtin_arc_sr((unsigned int)val, (volatile uint32_t)reg)
+
+#endif /* __CCAC__ */
+
+/**
+ * @fn void arc_halt(void)
+ * @brief Call kflag instruction to change status32
+ *
+ * @param flag Flag to set in status32
+ */
+Inline void arc_halt(void)
+{
+    /*sr cannot write AUX_STATUS32 */
+    Asm("kflag %0" ::"ir" (1));
+}
+
+/**
+ * @fn uint32_t arc_clri(void)
+ * @brief Call clri instruction
+ * call a clri instruction to disable interrupt
+ * @return interrupt related bits in status32
+ */
+Inline uint32_t arc_clri(void)
+{
+    uint32_t v;
+
+    Asm("clri %0" : "=r" (v):: "memory");
+    return v;
+}
+
+/**
+ * @fn void arc_seti(uint32_t key)
+ * @brief Call seti instruction
+ * call a set instruction to change interrupt status
+ * @param key  interrupt status
+ */
+Inline void arc_seti(uint32_t key)
+{
+    Asm("seti %0" : : "ir" (key) : "memory");
+}
+
+#endif  /* __ASSEMBLY__ */
+
+/** @} */
+#endif /* _ARC_HAL_BUILTIN_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_exception.c
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_exception.c
@@ -1,0 +1,251 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief C Implementation of exception and interrupt management
+ */
+#include "arc/arc_exception.h"
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ * @var exc_entry_table
+ * @brief exception entry table
+ *
+ * install exception entry table to ARC_AUX_INT_VECT_BASE in startup.
+ * According to ARCv2 ISA, vectors are fetched in instruction space and thus
+ * may be present in ICCM, Instruction Cache, or
+ * main memory accessed by instruction fetch logic.
+ * So it is put into a specific section .vector.
+ *
+ * Please note that the exc_entry_table maybe cached in ARC. Some functions is
+ * defined in .s files.
+ *
+ */
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  default cpu exception handler
+ * @param p_excinf pointer to the exception frame
+ */
+static void exc_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  default interrupt handler
+ * @param[in] p_excinf	information for interrupt handler
+ */
+static void int_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_ENTRY_TABLE == 1
+__attribute__ ((aligned(1024), section(".vector")))
+EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL] = {
+    [0] = _arc_reset,
+    [1 ... NUM_EXC_CPU - 1] = exc_entry_cpu,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = exc_entry_int
+};
+#endif
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_INT_HANDLER_TABLE == 1
+/**
+ * @var exc_int_handler_table
+ * @brief the cpu exception and interrupt exception handler table
+ * called in exc_entry_default and exc_entry_int
+ */
+EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL] = {
+    [0 ... NUM_EXC_CPU - 1] = exc_handler_default,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = int_handler_default
+};
+#endif
+
+typedef struct aux_irq_ctrl_field {
+    /* note: little endian */
+    uint32_t save_nr_gpr_pairs : 5;         /** Indicates number of general-purpose register pairs saved, from 0 to 8/16 */
+    uint32_t res : 4;                       /** Reserved */
+    uint32_t save_blink : 1;                /** Indicates whether to save and restore BLINK */
+    uint32_t save_lp_regs : 1;              /** Indicates whether to save and restore loop registers (LP_COUNT, LP_START, LP_END) */
+    uint32_t save_u_to_u : 1;               /** Indicates if user context is saved to user stack */
+    uint32_t res2 : 1;                      /** Reserved */
+    uint32_t save_idx_regs : 1;             /** Indicates whether to save and restore code-density registers (EI_BASE, JLI_BASE, LDI_BASE) */
+    uint32_t res3 : 18;                     /** Reserved */
+} aux_irq_ctrl_field_t;
+
+typedef union {
+    aux_irq_ctrl_field_t bits;
+    uint32_t value;
+} aux_irq_ctrl_t;
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  initialize the exception and interrupt handling
+ */
+void exc_int_init(void)
+{
+    uint32_t i;
+    uint32_t status;
+    aux_irq_ctrl_t ictrl;
+
+    ictrl.value = 0;
+
+    ictrl.bits.save_nr_gpr_pairs = 6;       /* r0 to r11 (r12 saved manually) */
+
+    ictrl.bits.save_blink = 1;
+    ictrl.bits.save_lp_regs = 1;            /* LP_COUNT, LP_START, LP_END */
+    ictrl.bits.save_u_to_u = 0;             /* user ctxt saved on kernel stack */
+
+    status = arc_lock_save();
+    for (i = NUM_EXC_CPU; i < NUM_EXC_ALL; i++) {
+        /* interrupt level triggered, disabled, priority is the lowest */
+        arc_aux_write(AUX_IRQ_SELECT, i);
+        arc_aux_write(AUX_IRQ_ENABLE, 0);
+        arc_aux_write(AUX_IRQ_TRIGGER, 0);
+        arc_aux_write(AUX_IRQ_PRIORITY, INT_PRI_MAX - INT_PRI_MIN);
+    }
+    arc_aux_write(AUX_IRQ_CTRL, ictrl.value);
+
+    arc_unlock_restore(status);
+
+    /** ipm should be set after cpu unlock restore to avoid reset of the status32 value */
+    arc_int_ipm_set((INT_PRI_MAX - INT_PRI_MIN));
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  install an exception handler
+ * @param[in] excno	exception number
+ * @param[in] handler the handler of exception to install
+ */
+/**
+ * warning: only work in simulation and it won't work on any real platform with caches, including
+ * nsim with cache enabled.
+ */
+static int32_t exc_handler_install(const uint32_t excno, EXC_HANDLER_T handler)
+{
+    if (excno < NUM_EXC_ALL && handler != NULL) {
+        exc_int_handler_table[excno] = handler;
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_disable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_disable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_enable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_enable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ * @return  <0 error, 0 ok
+ */
+int32_t int_pri_set(const uint32_t intno, int32_t intpri)
+{
+    uint32_t status;
+
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        status = cpu_lock_save();
+        intpri = intpri - INT_PRI_MIN;
+        arc_int_pri_set(intno, (uint32_t)intpri);
+        cpu_unlock_restore(status);
+        return 0;
+    }
+    return -1;
+}
+
+/**
+ * @brief  lock cpu and return status
+ *
+ * @returns cpu status
+ */
+uint32_t cpu_lock_save(void)
+{
+    return arc_lock_save();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+void cpu_unlock_restore(const uint32_t status)
+{
+    arc_unlock_restore(status);
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  install an interrupt handler
+ * @param[in] intno	interrupt number
+ * @param[in] handler interrupt handler to install
+ */
+int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler)
+{
+    /*!< @todo parameter check ? */
+    if (intno >= NUM_EXC_CPU) {
+        return exc_handler_install(intno, handler);
+    }
+
+    return -1;
+}
+
+/** @} end of group ARC_HAL_EXCEPTION_CPU */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_exception.h
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_exception.h
@@ -1,0 +1,256 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief header file of exception and interrupt management module
+ */
+
+#ifndef _ARC_HAL_EXCEPTION_H_
+#define _ARC_HAL_EXCEPTION_H_
+
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+#ifndef __ASSEMBLY__
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+#ifndef NUM_EXC_CPU
+/*!< number of CPU exceptions */
+#define NUM_EXC_CPU             16
+#endif
+
+/*!< total number of exceptions */
+#define NUM_EXC_ALL             (NUM_EXC_CPU + NUM_EXC_INT)
+
+typedef struct int_exc_frame {
+	uint32_t erbta;
+
+	uint32_t r30;   /* r30 is useless, skipped? */
+	uint32_t ilink; /* r29 is useless, skipped?*/
+	/* r28 is sp, saved other place */
+	uint32_t fp;    /* r27 */
+	uint32_t gp;    /* r26 */
+
+	uint32_t r12;
+	uint32_t r0, r1, r2, r3;
+	uint32_t r4, r5, r6, r7, r8, r9;
+	uint32_t r10, r11;
+	uint32_t blink; /* r31 */
+	uint32_t lp_end, lp_start, lp_count;
+	uint32_t ret;
+	uint32_t status32;
+} __attribute__((packed)) INT_EXC_FRAME_T;
+
+typedef struct callee_frame {
+	uint32_t r25;
+	uint32_t r24;
+	uint32_t r23;
+	uint32_t r22;
+	uint32_t r21;
+	uint32_t r20;
+	uint32_t r19;
+	uint32_t r18;
+	uint32_t r17;
+	uint32_t r16;
+	uint32_t r15;
+	uint32_t r14;
+	uint32_t r13;
+} __attribute__((packed)) CALLEE_FRAME_T;
+
+typedef struct processor_frame {
+	CALLEE_FRAME_T callee_regs;
+	INT_EXC_FRAME_T exc_frame;
+} __attribute__((packed)) PROCESSOR_FRAME_T;
+
+#define ARC_PROCESSOR_FRAME_T_SIZE        (sizeof(PROCESSOR_FRAME_T) / sizeof(uint32_t))
+#define ARC_EXC_FRAME_T_SIZE              (sizeof(INT_EXC_FRAME_T) / sizeof(uint32_t))
+#define ARC_CALLEE_FRAME_T_SIZE           (sizeof(CALLEE_FRAME_T) / sizeof(uint32_t))
+
+extern uint32_t exc_nest_count;
+
+#define INT_PRI_MAX (-1)                /*!< the maximum interrupt priority */
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_disable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 0);
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_enable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 1);
+}
+
+/**
+ * @brief  set the interrupt priority mask
+ *
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_ipm_set(uint32_t intpri)
+{
+	volatile uint32_t status;
+
+	status = arc_aux_read(AUX_STATUS32) & ~0x1e;
+
+	status = status | ((intpri << 1) & 0x1e);
+	/* sr cannot write AUX_STATUS32 */
+	Asm("kflag %0" ::"ir" (status));
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_pri_set(const uint32_t intno, uint32_t intpri)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_PRIORITY, intpri | (arc_aux_read(AUX_IRQ_PRIORITY) & 0xfffffff0));
+}
+
+/**
+ * @brief  lock cpu, disable interrupts
+ */
+Inline void arc_lock(void)
+{
+	arc_clri();
+}
+
+/**
+ * @brief  unlock cpu, enable interrupts to happen
+ */
+Inline void arc_unlock(void)
+{
+	arc_seti(0);
+}
+
+/**
+ * @brief  lock cpu and status
+ *
+ * @returns cpu status
+ */
+Inline uint32_t arc_lock_save(void)
+{
+	return arc_clri();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+Inline void arc_unlock_restore(const uint32_t status)
+{
+	arc_seti(status);
+}
+
+/** @}*/
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @typedef EXC_ENTRY_T
+ * @brief  the data type for exception entry
+ */
+typedef void (*EXC_ENTRY_T) (void);
+/**
+ * @typedef EXC_HANDLER_T
+ * @brief  the data type for exception handler
+ */
+typedef void (*EXC_HANDLER_T) (void *exc_frame);
+/** @}*/
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @typedef INT_HANDLER_T
+ * @brief  the data type for interrupt handler
+ */
+typedef void (*INT_HANDLER_T) (void *ptr);
+
+extern EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL];
+extern EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL];
+
+/** @ingroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @fn _arc_reset
+ * @brief the reset entry
+ */
+extern void _arc_reset(void);
+/**
+ * @fn exc_entry_cpu
+ * @brief the default CPU exception entry
+ */
+extern void exc_entry_cpu(void);
+
+/**
+ * @fn exc_entry_int
+ * @brief the interrupt exception entry
+ */
+extern void exc_entry_int(void);
+/** @}*/
+
+/* exception related APIs */
+extern void exc_int_init(void);
+
+/* interrupt related APIs */
+extern int32_t int_disable(const uint32_t intno);
+extern int32_t int_enable(const uint32_t intno);
+
+/**
+ * @brief  get current interrupt priority mask
+ *
+ * @param[in] intno interrupt number
+ * @return  <0 interrupt priority, 0 error
+ */
+extern int32_t int_pri_set(const uint32_t intno, int32_t intpri);
+extern uint32_t cpu_lock_save(void);
+extern void cpu_unlock_restore(const uint32_t status);
+extern int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler);
+
+#endif  /* __ASSEMBLY__ */
+
+#endif /* _ARC_HAL_EXCEPTION_H_*/

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_timer.c
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_timer.c
@@ -1,0 +1,274 @@
+/*
+* FreeRTOS Kernel V10.6.0
+* Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of
+* this software and associated documentation files (the "Software"), to deal in
+* the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+* the Software, and to permit persons to whom the Software is furnished to do so,
+* subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+* FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+* IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* https://www.FreeRTOS.org
+* https://github.com/FreeRTOS
+*
+* 1 tab == 4 spaces!
+*/
+
+/**
+ * @file
+ * @ingroup	ARC_HAL_MISC_TIMER
+ * @brief  implementation of internal timer related functions
+ * @todo RTC support should be improved if RTC is enabled
+ */
+#include "arc/arc_timer.h"
+#include "arc/arc_exception.h"
+
+/**
+ * @brief  check whether the specific timer present
+ * @param[in] no timer number
+ * @return 1 present, 0 not present
+ */
+int32_t arc_timer_present(const uint32_t no)
+{
+    uint32_t bcr = arc_aux_read(AUX_BCR_TIMERS);
+
+    switch (no) {
+      case TIMER_0:
+          bcr = (bcr >> 8) & 1;
+          break;
+
+      case TIMER_1:
+          bcr = (bcr >> 9) & 1;
+          break;
+
+      case RTC_TIMER:
+          bcr = (bcr >> 10) & 1;
+          break;
+
+      case SECURE_TIMER_0:
+          bcr = (bcr >> 11) & 1;
+          break;
+
+      case SECURE_TIMER_1:
+          bcr = (bcr >> 12) & 1;
+          break;
+
+      default:
+          bcr = 0;
+          break;
+    }
+
+    return (int)bcr;
+}
+
+static void arc_timer0_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_TIMER0_LIMIT, val);
+    arc_aux_write(AUX_TIMER0_CTRL, mode);
+    arc_aux_write(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_TIMER1_LIMIT, val);
+    arc_aux_write(AUX_TIMER1_CTRL, mode);
+    arc_aux_write(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_start(const uint32_t mode) {
+    /* Enable with bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Accept A1 & A0 from mode bits 31 & 30 */
+    arc_aux_write(AUX_RTC_CTRL, (mode & 0xC0000003));
+}
+
+static void arc_secure_timer0_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_LIMIT, val);
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, mode);
+    arc_aux_write(AUX_SECURE_TIMER0_CNT, 0);
+}
+
+static void arc_secure_timer1_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_LIMIT, val);
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, mode);
+    arc_aux_write(AUX_SECURE_TIMER1_CNT, 0);
+}
+
+/**
+ * @brief  start the specific timer
+ * @param[in] no	timer number
+ * @param[in] mode	timer mode
+ * @param[in] val	timer limit value (not for RTC)
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint32_t val)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_start(mode, val);
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_start(mode, val);
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_start(mode);
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_start(mode, val);
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_start(mode, val);
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_stop() {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_TIMER0_LIMIT, 0);
+    arc_aux_write(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_stop() {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_TIMER1_LIMIT, 0);
+    arc_aux_write(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_stop() {
+    /* Zero the Enable bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Reserved bits ignored on write, Preserve A1, A0 in bits 31 & 30 */
+    uint32_t mode = arc_aux_read(AUX_RTC_CTRL) & ~0x1;
+    arc_aux_write(AUX_RTC_CTRL, mode);
+}
+
+static void arc_secure_timer0_stop() {
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_LIMIT, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_CNT, 0);
+}
+
+static void arc_secure_timer1_stop() {
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_LIMIT, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_CNT, 0);
+}
+
+/**
+ * @brief  stop and clear the specific timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_stop(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_stop();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_stop();
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_stop();
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_stop();
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_stop();
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER0_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER0_CTRL, val);
+}
+
+static void arc_timer1_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER1_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER1_CTRL, val);
+}
+
+static void arc_secure_timer0_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_SECURE_TIMER0_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, val);
+}
+
+static void arc_secure_timer1_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_SECURE_TIMER1_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, val);
+}
+
+/**
+ * @brief  clear the interrupt pending bit of timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_int_clear(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_int_clear();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_int_clear();
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_int_clear();
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_int_clear();
+            return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  init internal timer
+ */
+void arc_timer_init(void)
+{
+    if (arc_timer_present(TIMER_0)) {
+        arc_timer_stop(TIMER_0);
+    }
+}

--- a/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_timer.h
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/arc/arc_timer.h
@@ -1,0 +1,75 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC_TIMER
+ * \brief header file of ARC internal timer
+ */
+
+/**
+ * \addtogroup ARC_HAL_MISC_TIMER
+ * @{
+ */
+
+#ifndef _ARC_HAL_TIMER_H_
+#define _ARC_HAL_TIMER_H_
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+/**
+ * \name arc internal timers names
+ * @{
+ */
+#define TIMER_0         0   /*!< macro name for arc internal timer 0 */
+#define TIMER_1         1   /*!< macro name for arc internal timer 1 */
+#define RTC_TIMER       2   /*!< macro name for arc internal RTC */
+#define SECURE_TIMER_0  3   /*!< macro name for arc internal secure timer 0 */
+#define SECURE_TIMER_1  4   /*!< macro name for arc internal secure timer 1 */
+
+#define INTNO_TIMER0 ARC_FEATURE_TIMER0_VECTOR
+
+/** @} */
+
+/**
+ * \name bit definition of timer CTRL reg
+ * @{
+ */
+#define TIMER_CTRL_IE           (1 << 0)        /*!< Interrupt when count reaches limit */
+#define TIMER_CTRL_NH           (1 << 1)        /*!< Count only when CPU NOT halted */
+#define TIMER_CTRL_W            (1 << 2)        /*!< watchdog enable */
+#define TIMER_CTRL_IP           (1 << 3)        /*!< interrupt pending */
+
+/** @} */
+extern int32_t arc_timer_present(const uint32_t no);
+extern int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint32_t val);
+extern int32_t arc_timer_stop(const uint32_t no);
+extern int32_t arc_timer_int_clear(const uint32_t no);
+extern void arc_timer_init(void);
+
+#endif  /* _ARC_HAL_TIMER_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARC_EM_HS/port.c
+++ b/portable/ThirdParty/GCC/ARC_EM_HS/port.c
@@ -204,7 +204,7 @@ void vPortEndTask( void )
 /*
  * !!! Note !!!
  * This a trick!!!
- * It's a copy from task.c. We need to konw the definition of TCB for the purpose of hardware
+ * It's a copy from tasks.c. We need to know the definition of TCB for the purpose of hardware
  * stack check. Pls don't forget to update it when FreeRTOS is updated.
  */
     typedef struct tskTaskControlBlock       /* The old naming convention is used to prevent breaking kernel aware debuggers. */
@@ -256,11 +256,11 @@ void vPortEndTask( void )
         #endif
 
         #if ( configUSE_TASK_NOTIFICATIONS == 1 )
-            volatile uint32_t ulNotifiedValue;
-            volatile uint8_t ucNotifyState;
+            volatile uint32_t ulNotifiedValue[ configTASK_NOTIFICATION_ARRAY_ENTRIES ];
+            volatile uint8_t ucNotifyState[ configTASK_NOTIFICATION_ARRAY_ENTRIES ];
         #endif
 
-        /* See the comments above the definition of
+        /* See the comments in FreeRTOS.h with the definition of
          * tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
         #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 ) /*lint !e731 !e9029 Macro has been consolidated for readability reasons. */
             uint8_t ucStaticallyAllocated;                     /*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made to free the memory. */

--- a/portable/ThirdParty/GCC/ARC_v1/port.c
+++ b/portable/ThirdParty/GCC/ARC_v1/port.c
@@ -256,11 +256,11 @@ void vPortEndTask( void )
         #endif
 
         #if ( configUSE_TASK_NOTIFICATIONS == 1 )
-            volatile uint32_t ulNotifiedValue;
-            volatile uint8_t ucNotifyState;
+            volatile uint32_t ulNotifiedValue[ configTASK_NOTIFICATION_ARRAY_ENTRIES ];
+            volatile uint8_t ucNotifyState[ configTASK_NOTIFICATION_ARRAY_ENTRIES ];
         #endif
 
-        /* See the comments above the definition of
+        /* See the comments in FreeRTOS.h with the definition of
          * tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
         #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 ) /*lint !e731 !e9029 Macro has been consolidated for readability reasons. */
             uint8_t ucStaticallyAllocated;                     /*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made to free the memory. */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc.h
@@ -1,0 +1,125 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_CORE_COMM
+ * \brief  header file including common core definitions
+ */
+
+/**
+ * \addtogroup ARC_HAL_CORE_COMM
+ * @{
+ */
+
+#ifndef _ARC_HAL_CORE_H_
+#define _ARC_HAL_CORE_H_
+
+#include "arc_feature_config.h"
+
+#define AUX_BCR_TIMERS                  (0x75)                      /*!< build configuration for processor timers */
+#define AUX_STATUS32                    (0xa)
+#define AUX_STATUS_BIT_AE               (5)                         /*!< processor is in an exception */
+#define AUX_STATUS_BIT_IE               (31)                        /*!< interrupt enable */
+#define AUX_STATUS_BIT_HALT             (0)                         /*!< halt bit */
+#define AUX_STATUS_BIT_SC               (14)                        /*!< stack check bit */
+#define AUX_STATUS_BIT_US               (20)                        /*!< user sleep mode enable bit */
+#define AUX_STATUS_MASK_IE              (1 << AUX_STATUS_BIT_IE)    /*!< mask of AUX_STATUS_BIT_IE */
+#define AUX_STATUS_MASK_HALT            (1 << AUX_STATUS_BIT_HALT)  /*!< mask of AUX_STATUS_BIT_HALT */
+#define AUX_STATUS_MASK_US              (1 << AUX_STATUS_BIT_US)    /*!< mask of AUX_STATUS_BIT_US */
+#define STATUS32_RESET_VALUE            (AUX_STATUS_MASK_US)
+#define AUX_LP_START                    (0x2)                       /*!< loop start address (32-bit) */
+#define AUX_LP_END                      (0x3)                       /*!< loop end address (32-bit) */
+#define AUX_IDENTITY                    (0x4)                       /*!< core identity register (32-bit) */
+#define AUX_IDENTITY_ARCVER_MASK        (0x00FF)                    /*!< mask of core identity register ARCVER */
+#define AUX_IDENTITY_ARCNUM_MASK        (0xFF00)                    /*!< mask of core identity register ARCNUM */
+#define AUX_KSTACK_TOP                  (0x264)
+#define AUX_KSTACK_BASE                 (0x265)
+#define AUX_TIMER0_CNT                  (0x21)                      /*!< timer 0 count value */
+#define AUX_TIMER0_CTRL                 (0x22)                      /*!< timer 0 control value */
+#define AUX_TIMER0_LIMIT                (0x23)                      /*!< timer 0 limit value */
+#define AUX_TIMER1_CNT                  (0x100)                     /*!< timer 1 count value */
+#define AUX_TIMER1_CTRL                 (0x101)                     /*!< timer 1 control value */
+#define AUX_TIMER1_LIMIT                (0x102)                     /*!< timer 1 limit value */
+#define AUX_RTC_CTRL                    (0x103)                     /*!< RTC control value */
+#define AUX_RTC_LOW                     (0x104)                     /*!< RTC count low value */
+#define AUX_RTC_HIGH                    (0x105)                     /*!< RTC count high value */
+#define AUX_SECURE_TIMER0_CNT           (0x106)                     /*!< secure timer 0 count value */
+#define AUX_SECURE_TIMER0_CTRL          (0x107)                     /*!< secure timer 0 control value */
+#define AUX_SECURE_TIMER0_LIMIT         (0x108)                     /*!< secure timer 0 limit value */
+#define AUX_SECURE_TIMER1_CNT           (0x109)                     /*!< secure timer 1 count value */
+#define AUX_SECURE_TIMER1_CTRL          (0x10a)                     /*!< secure timer 1 control value */
+#define AUX_SECURE_TIMER1_LIMIT         (0x10b)                     /*!< secure timer 1 limit value */
+#define AUX_ERRET                       (0x400)                     /*!< exception return address */
+#define AUX_ERBTA                       (0x401)                     /*!< BTA saved on exception entry */
+#define AUX_ERSTATUS                    (0x402)                     /*!< STATUS32 saved on exception */
+#define AUX_ECR                         (0x403)                     /*!< exception cause register */
+#define AUX_IRQ_CTRL                    (0xe)                       /*!< interrupt context saving control register */
+#define AUX_INT_VECT_BASE               (0x25)                      /*!< interrupt vector base register */
+#define AUX_IRQ_ACT                     (0x43)                      /*!< active interrupts register */
+#define AUX_IRQ_CAUSE                   (0x40a)                     /*!< interrupt cause register */
+#define AUX_IRQ_SELECT                  (0x40b)                     /*!< interrupt select register */
+#define AUX_IRQ_PRIORITY                (0x206)                     /*!< interrupt priority register */
+#define AUX_IRQ_ENABLE                  (0x40c)                     /*!< interrupt enable register */
+#define AUX_IRQ_TRIGGER                 (0x40d)                     /*!< interrupt trigger: level or pulse */
+#define AUX_IRQ_STATUS                  (0x40f)                     /*!< interrupt status register */
+#define AUX_IRQ_HINT                    (0x201)                     /*!< software interrupt trigger */
+
+/* For SMP */
+#define ARCONNECT_INTRPT_LINE               (0x13)                  /*!< ARConnect Inter-core interrupt line, irq19 */
+
+#define AUX_CONNECT_SYSTEM_BUILD            (0xd0)                  /*!< ARConnect Build Configuration Register */
+#define AUX_CONNECT_ICI_BUILD               (0xe0)                  /*!< Inter-Core Interrupt Unit BCR */
+
+#define ARCONNECT_CMD                       (0x600)                 /*!< ARConnect command register */
+#define ARCONNECT_WDATA                     (0x601)                 /*!< ARConnect Write data register */
+#define ARCONNECT_READBACK                  (0x602)                 /*!< ARConnect Read data register */
+#define ARCONNECT_READBACK_64               (0x603)                 /*!< ARConnect Read 64-bit data register */
+
+#define ARCONNECT_CMD_CHECK_CORE_ID         (0x00)                  /*!< ARConnect command CMD_CHECK_CORE_ID */
+#define ARCONNECT_CMD_INTRPT_GENERATE_IRQ   (0x01)                  /*!< ARConnect command CMD_INTRPT_GENERATE_IRQ */
+#define ARCONNECT_CMD_INTRPT_GENERATE_ACK   (0x02)                  /*!< ARConnect command CMD_INTRPT_GENERATE_ACK */
+#define ARCONNECT_CMD_INTRPT_READ_STATUS    (0x03)                  /*!< ARConnect command CMD_INTRPT_READ_STATUS */
+#define ARCONNECT_CMD_INTRPT_CHECK_SOURCE   (0x04)                  /*!< ARConnect command CMD_INTRPT_CHECK_SOURCE */
+/* End For SMP */
+
+#ifndef __ASSEMBLY__
+
+#include <stdint.h>     /* C99 standard lib */
+#include <limits.h>     /* C99 standard lib */
+#include <stddef.h>     /* C99 standard lib */
+#include <stdbool.h>    /* C99 standard lib */
+
+#define Inline  static __inline__               /* inline function */
+
+#define Asm     __asm__ volatile                /* inline asm (no optimization) */
+
+#endif  /* __ASSEMBLY__ */
+
+#endif  /* _ARC_HAL_CORE_H_ */
+
+// /**  @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_asm_common.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_asm_common.h
@@ -1,0 +1,264 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC
+ * \brief common macro definitions for assembly file
+ */
+/** @cond ARC_HAL_ASM_COMMON */
+
+#ifndef _ARC_HAL_ASM_COMMON_H_
+#define _ARC_HAL_ASM_COMMON_H_
+
+#include "arc/arc.h"
+
+#ifdef __ASSEMBLY__
+/* the assembly macro definitions in ARC GNU and MWDT are
+ * different, so need different processing
+ */
+#if defined(__GNU__)
+#define MACRO_ARG(x) \x
+#define ASM_MACRO1(name, arg1) name arg1
+#else
+#define MACRO_ARG(x) x
+#define ASM_MACRO1(name, arg1) name, arg1
+#endif
+
+/* Note on the LD/ST addr modes with addr reg wback
+ *
+ * LD.a same as LD.aw
+ *
+ * LD.a    reg1, [reg2, x]  => Pre Incr
+ *      Eff Addr for load = [reg2 + x]
+ *
+ * LD.ab   reg1, [reg2, x]  => Post Incr
+ *      Eff Addr for load = [reg2]
+ */
+.macro ASM_MACRO1(PUSHAX, aux)
+	lr r10, [MACRO_ARG(aux)]
+	PUSH r10
+.endm
+
+.macro ASM_MACRO1(POPAX, aux)
+	POP r10
+	sr r10, [MACRO_ARG(aux)]
+.endm
+
+/*--------------------------------------------------------------
+ * Helpers to save/restore callee-saved regs:
+ * used by several macros below
+ *-------------------------------------------------------------*/
+.macro SAVE_CALLEE_REGS
+	PUSH	r13
+	PUSH	r14
+	PUSH	r15
+	PUSH	r16
+	PUSH	r17
+	PUSH	r18
+	PUSH	r19
+	PUSH	r20
+	PUSH	r21
+	PUSH	r22
+	PUSH	r23
+	PUSH	r24
+	PUSH	r25
+.endm
+
+.macro RESTORE_CALLEE_REGS
+	POP	r25
+	POP	r24
+	POP	r23
+	POP	r22
+	POP	r21
+	POP	r20
+	POP	r19
+	POP	r18
+	POP	r17
+	POP	r16
+	POP	r15
+	POP	r14
+	POP	r13
+.endm
+
+.macro SAVE_LP_REGS
+	PUSH	r60
+	PUSHAX	AUX_LP_START
+	PUSHAX	AUX_LP_END
+.endm
+
+.macro RESTORE_LP_REGS
+	POPAX	AUX_LP_END
+	POPAX	AUX_LP_START
+	POP	r10
+/* must not use the LP_COUNT register(r60) as the destination of multi-cycle instruction */
+	mov	r60, r10
+
+.endm
+
+/* macro to save r0 to r12 */
+.macro SAVE_R0_TO_R12
+	PUSH	r0
+	PUSH	r1
+	PUSH	r2
+	PUSH	r3
+	PUSH	r4
+	PUSH	r5
+	PUSH	r6
+	PUSH	r7
+	PUSH	r8
+	PUSH	r9
+	PUSH	r10
+	PUSH	r11
+	PUSH	r12
+.endm
+
+/* macro to restore r0 to r12 */
+.macro RESTORE_R0_TO_R12
+	POP	r12
+	POP	r11
+	POP	r10
+	POP	r9
+	POP	r8
+	POP	r7
+	POP	r6
+	POP	r5
+	POP	r4
+	POP	r3
+	POP	r2
+	POP	r1
+	POP	r0
+.endm
+
+/* macro to save all non-caller saved regs */
+.macro SAVE_NONSCRATCH_REGS
+/* caller saved regs are saved by caller function */
+	PUSH	gp
+	PUSH	fp
+	PUSH	blink
+	SAVE_CALLEE_REGS
+.endm
+
+/* macro to restore all non-caller saved regs */
+.macro RESTORE_NONSCRATCH_REGS
+	RESTORE_CALLEE_REGS
+	POP	blink
+	POP	fp
+	POP	gp
+.endm
+
+/* normal interrupt prologue, pc, status and r0-r11 are saved by hardware */
+.macro INTERRUPT_PROLOGUE
+	PUSH	r12
+	PUSH	gp
+	PUSH	fp
+	PUSH	ilink
+	PUSH	r30
+
+	sub	sp, sp, 4 /* skip bta */
+.endm
+
+
+/* normal interrupt epilogue, pc, status and r0-r11 are restored by hardware */
+.macro INTERRUPT_EPILOGUE
+	add	sp, sp, 4 /* skip bta */
+
+	POP	r30
+	POP	ilink
+	POP	fp
+	POP	gp
+	POP	r12
+.endm
+
+/* exception prologue, create the same frame of interrupt manually */
+.macro EXCEPTION_PROLOGUE
+	st.as	r10, [sp, -8]
+	PUSHAX	AUX_ERSTATUS
+	PUSHAX	AUX_ERRET
+
+	SAVE_LP_REGS
+
+	PUSH	blink
+
+	PUSH	r11
+	sub	sp, sp, 4 /* r10 is  pushed before */
+	PUSH	r9
+	PUSH	r8
+	PUSH	r7
+	PUSH	r6
+	PUSH	r5
+	PUSH	r4
+	PUSH	r3
+	PUSH	r2
+	PUSH	r1
+	PUSH	r0
+
+	PUSH	r12
+	PUSH	gp
+	PUSH	fp
+	PUSH	ilink
+	PUSH	r30
+
+	PUSHAX	AUX_ERBTA
+.endm
+
+/* exception epilogue, restore the same frame of interrupt manually */
+.macro EXCEPTION_EPILOGUE
+	POPAX	AUX_ERBTA
+
+	POP	r30
+	POP	ilink
+	POP	fp
+	POP	gp
+	POP	r12
+
+	POP	r0
+	POP	r1
+	POP	r2
+	POP	r3
+	POP	r4
+	POP	r5
+	POP	r6
+	POP	r7
+	POP	r8
+	POP	r9
+	add	sp, sp, 4 /* r10 will be popped finally */
+	POP	r11
+
+	POP	blink
+
+	RESTORE_LP_REGS
+
+	POPAX	AUX_ERRET
+	POPAX	AUX_ERSTATUS
+
+	ld.as	r10, [sp, -8]
+.endm
+
+#endif  /* __ASSEMBLY__ */
+#endif	/* _ARC_HAL_ASM_COMMON_H */
+/** @endcond */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_builtin.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_builtin.h
@@ -1,0 +1,101 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_BUILTIN
+ * @brief Header file of builtin and helper functions
+ *
+ * The Metaware toolchain and the GNU toolchain are supported. The details please go to see the file.
+ */
+
+/**
+ * @addtogroup	ARC_HAL_BUILTIN
+ * @{
+ */
+
+#ifndef _ARC_HAL_BUILTIN_H_
+#define _ARC_HAL_BUILTIN_H_
+
+#include "arc/arc.h"
+
+#ifndef __ASSEMBLY__
+
+#if defined(__CCAC__)
+
+#define arc_aux_read(reg) _lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) _sr((unsigned int)val, (volatile uint32_t)reg)
+
+#else /* ! __CCAC__ */
+
+#define arc_aux_read(reg) __builtin_arc_lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) __builtin_arc_sr((unsigned int)val, (volatile uint32_t)reg)
+
+#endif /* __CCAC__ */
+
+/**
+ * @fn void arc_halt(void)
+ * @brief Call kflag instruction to change status32
+ *
+ * @param flag Flag to set in status32
+ */
+Inline void arc_halt(void)
+{
+    /*sr cannot write AUX_STATUS32 */
+    Asm("kflag %0" ::"ir" (1));
+}
+
+/**
+ * @fn uint32_t arc_clri(void)
+ * @brief Call clri instruction
+ * call a clri instruction to disable interrupt
+ * @return interrupt related bits in status32
+ */
+Inline uint32_t arc_clri(void)
+{
+    uint32_t v;
+
+    Asm("clri %0" : "=r" (v):: "memory");
+    return v;
+}
+
+/**
+ * @fn void arc_seti(uint32_t key)
+ * @brief Call seti instruction
+ * call a set instruction to change interrupt status
+ * @param key  interrupt status
+ */
+Inline void arc_seti(uint32_t key)
+{
+    Asm("seti %0" : : "ir" (key) : "memory");
+}
+
+#endif  /* __ASSEMBLY__ */
+
+/** @} */
+#endif /* _ARC_HAL_BUILTIN_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_exception.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_exception.c
@@ -1,0 +1,251 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief C Implementation of exception and interrupt management
+ */
+#include "arc/arc_exception.h"
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ * @var exc_entry_table
+ * @brief exception entry table
+ *
+ * install exception entry table to ARC_AUX_INT_VECT_BASE in startup.
+ * According to ARCv2 ISA, vectors are fetched in instruction space and thus
+ * may be present in ICCM, Instruction Cache, or
+ * main memory accessed by instruction fetch logic.
+ * So it is put into a specific section .vector.
+ *
+ * Please note that the exc_entry_table maybe cached in ARC. Some functions is
+ * defined in .s files.
+ *
+ */
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  default cpu exception handler
+ * @param p_excinf pointer to the exception frame
+ */
+static void exc_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  default interrupt handler
+ * @param[in] p_excinf	information for interrupt handler
+ */
+static void int_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_ENTRY_TABLE == 1
+__attribute__ ((aligned(1024), section(".vector")))
+EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL] = {
+    [0] = _arc_reset,
+    [1 ... NUM_EXC_CPU - 1] = exc_entry_cpu,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = exc_entry_int
+};
+#endif
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_INT_HANDLER_TABLE == 1
+/**
+ * @var exc_int_handler_table
+ * @brief the cpu exception and interrupt exception handler table
+ * called in exc_entry_default and exc_entry_int
+ */
+EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL] = {
+    [0 ... NUM_EXC_CPU - 1] = exc_handler_default,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = int_handler_default
+};
+#endif
+
+typedef struct aux_irq_ctrl_field {
+    /* note: little endian */
+    uint32_t save_nr_gpr_pairs : 5;         /** Indicates number of general-purpose register pairs saved, from 0 to 8/16 */
+    uint32_t res : 4;                       /** Reserved */
+    uint32_t save_blink : 1;                /** Indicates whether to save and restore BLINK */
+    uint32_t save_lp_regs : 1;              /** Indicates whether to save and restore loop registers (LP_COUNT, LP_START, LP_END) */
+    uint32_t save_u_to_u : 1;               /** Indicates if user context is saved to user stack */
+    uint32_t res2 : 1;                      /** Reserved */
+    uint32_t save_idx_regs : 1;             /** Indicates whether to save and restore code-density registers (EI_BASE, JLI_BASE, LDI_BASE) */
+    uint32_t res3 : 18;                     /** Reserved */
+} aux_irq_ctrl_field_t;
+
+typedef union {
+    aux_irq_ctrl_field_t bits;
+    uint32_t value;
+} aux_irq_ctrl_t;
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  initialize the exception and interrupt handling
+ */
+void exc_int_init(void)
+{
+    uint32_t i;
+    uint32_t status;
+    aux_irq_ctrl_t ictrl;
+
+    ictrl.value = 0;
+
+    ictrl.bits.save_nr_gpr_pairs = 6;       /* r0 to r11 (r12 saved manually) */
+
+    ictrl.bits.save_blink = 1;
+    ictrl.bits.save_lp_regs = 1;            /* LP_COUNT, LP_START, LP_END */
+    ictrl.bits.save_u_to_u = 0;             /* user ctxt saved on kernel stack */
+
+    status = arc_lock_save();
+    for (i = NUM_EXC_CPU; i < NUM_EXC_ALL; i++) {
+        /* interrupt level triggered, disabled, priority is the lowest */
+        arc_aux_write(AUX_IRQ_SELECT, i);
+        arc_aux_write(AUX_IRQ_ENABLE, 0);
+        arc_aux_write(AUX_IRQ_TRIGGER, 0);
+        arc_aux_write(AUX_IRQ_PRIORITY, INT_PRI_MAX - INT_PRI_MIN);
+    }
+    arc_aux_write(AUX_IRQ_CTRL, ictrl.value);
+
+    arc_unlock_restore(status);
+
+    /** ipm should be set after cpu unlock restore to avoid reset of the status32 value */
+    arc_int_ipm_set((INT_PRI_MAX - INT_PRI_MIN));
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  install an exception handler
+ * @param[in] excno	exception number
+ * @param[in] handler the handler of exception to install
+ */
+/**
+ * warning: only work in simulation and it won't work on any real platform with caches, including
+ * nsim with cache enabled.
+ */
+static int32_t exc_handler_install(const uint32_t excno, EXC_HANDLER_T handler)
+{
+    if (excno < NUM_EXC_ALL && handler != NULL) {
+        exc_int_handler_table[excno] = handler;
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_disable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_disable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_enable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_enable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ * @return  <0 error, 0 ok
+ */
+int32_t int_pri_set(const uint32_t intno, int32_t intpri)
+{
+    uint32_t status;
+
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        status = cpu_lock_save();
+        intpri = intpri - INT_PRI_MIN;
+        arc_int_pri_set(intno, (uint32_t)intpri);
+        cpu_unlock_restore(status);
+        return 0;
+    }
+    return -1;
+}
+
+/**
+ * @brief  lock cpu and return status
+ *
+ * @returns cpu status
+ */
+uint32_t cpu_lock_save(void)
+{
+    return arc_lock_save();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+void cpu_unlock_restore(const uint32_t status)
+{
+    arc_unlock_restore(status);
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  install an interrupt handler
+ * @param[in] intno	interrupt number
+ * @param[in] handler interrupt handler to install
+ */
+int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler)
+{
+    /*!< @todo parameter check ? */
+    if (intno >= NUM_EXC_CPU) {
+        return exc_handler_install(intno, handler);
+    }
+
+    return -1;
+}
+
+/** @} end of group ARC_HAL_EXCEPTION_CPU */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_exception.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_exception.h
@@ -1,0 +1,256 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief header file of exception and interrupt management module
+ */
+
+#ifndef _ARC_HAL_EXCEPTION_H_
+#define _ARC_HAL_EXCEPTION_H_
+
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+#ifndef __ASSEMBLY__
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+#ifndef NUM_EXC_CPU
+/*!< number of CPU exceptions */
+#define NUM_EXC_CPU             16
+#endif
+
+/*!< total number of exceptions */
+#define NUM_EXC_ALL             (NUM_EXC_CPU + NUM_EXC_INT)
+
+typedef struct int_exc_frame {
+	uint32_t erbta;
+
+	uint32_t r30;   /* r30 is useless, skipped? */
+	uint32_t ilink; /* r29 is useless, skipped?*/
+	/* r28 is sp, saved other place */
+	uint32_t fp;    /* r27 */
+	uint32_t gp;    /* r26 */
+
+	uint32_t r12;
+	uint32_t r0, r1, r2, r3;
+	uint32_t r4, r5, r6, r7, r8, r9;
+	uint32_t r10, r11;
+	uint32_t blink; /* r31 */
+	uint32_t lp_end, lp_start, lp_count;
+	uint32_t ret;
+	uint32_t status32;
+} __attribute__((packed)) INT_EXC_FRAME_T;
+
+typedef struct callee_frame {
+	uint32_t r25;
+	uint32_t r24;
+	uint32_t r23;
+	uint32_t r22;
+	uint32_t r21;
+	uint32_t r20;
+	uint32_t r19;
+	uint32_t r18;
+	uint32_t r17;
+	uint32_t r16;
+	uint32_t r15;
+	uint32_t r14;
+	uint32_t r13;
+} __attribute__((packed)) CALLEE_FRAME_T;
+
+typedef struct processor_frame {
+	CALLEE_FRAME_T callee_regs;
+	INT_EXC_FRAME_T exc_frame;
+} __attribute__((packed)) PROCESSOR_FRAME_T;
+
+#define ARC_PROCESSOR_FRAME_T_SIZE        (sizeof(PROCESSOR_FRAME_T) / sizeof(uint32_t))
+#define ARC_EXC_FRAME_T_SIZE              (sizeof(INT_EXC_FRAME_T) / sizeof(uint32_t))
+#define ARC_CALLEE_FRAME_T_SIZE           (sizeof(CALLEE_FRAME_T) / sizeof(uint32_t))
+
+extern uint32_t exc_nest_count[];
+
+#define INT_PRI_MAX (-1)                /*!< the maximum interrupt priority */
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_disable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 0);
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_enable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 1);
+}
+
+/**
+ * @brief  set the interrupt priority mask
+ *
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_ipm_set(uint32_t intpri)
+{
+	volatile uint32_t status;
+
+	status = arc_aux_read(AUX_STATUS32) & ~0x1e;
+
+	status = status | ((intpri << 1) & 0x1e);
+	/* sr cannot write AUX_STATUS32 */
+	Asm("kflag %0" ::"ir" (status));
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_pri_set(const uint32_t intno, uint32_t intpri)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_PRIORITY, intpri | (arc_aux_read(AUX_IRQ_PRIORITY) & 0xfffffff0));
+}
+
+/**
+ * @brief  lock cpu, disable interrupts
+ */
+Inline void arc_lock(void)
+{
+	arc_clri();
+}
+
+/**
+ * @brief  unlock cpu, enable interrupts to happen
+ */
+Inline void arc_unlock(void)
+{
+	arc_seti(0);
+}
+
+/**
+ * @brief  lock cpu and status
+ *
+ * @returns cpu status
+ */
+Inline uint32_t arc_lock_save(void)
+{
+	return arc_clri();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+Inline void arc_unlock_restore(const uint32_t status)
+{
+	arc_seti(status);
+}
+
+/** @}*/
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @typedef EXC_ENTRY_T
+ * @brief  the data type for exception entry
+ */
+typedef void (*EXC_ENTRY_T) (void);
+/**
+ * @typedef EXC_HANDLER_T
+ * @brief  the data type for exception handler
+ */
+typedef void (*EXC_HANDLER_T) (void *exc_frame);
+/** @}*/
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @typedef INT_HANDLER_T
+ * @brief  the data type for interrupt handler
+ */
+typedef void (*INT_HANDLER_T) (void *ptr);
+
+extern EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL];
+extern EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL];
+
+/** @ingroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @fn _arc_reset
+ * @brief the reset entry
+ */
+extern void _arc_reset(void);
+/**
+ * @fn exc_entry_cpu
+ * @brief the default CPU exception entry
+ */
+extern void exc_entry_cpu(void);
+
+/**
+ * @fn exc_entry_int
+ * @brief the interrupt exception entry
+ */
+extern void exc_entry_int(void);
+/** @}*/
+
+/* exception related APIs */
+extern void exc_int_init(void);
+
+/* interrupt related APIs */
+extern int32_t int_disable(const uint32_t intno);
+extern int32_t int_enable(const uint32_t intno);
+
+/**
+ * @brief  get current interrupt priority mask
+ *
+ * @param[in] intno interrupt number
+ * @return  <0 interrupt priority, 0 error
+ */
+extern int32_t int_pri_set(const uint32_t intno, int32_t intpri);
+extern uint32_t cpu_lock_save(void);
+extern void cpu_unlock_restore(const uint32_t status);
+extern int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler);
+
+#endif  /* __ASSEMBLY__ */
+
+#endif /* _ARC_HAL_EXCEPTION_H_*/

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_timer.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_timer.c
@@ -1,0 +1,274 @@
+/*
+* FreeRTOS Kernel <DEVELOPMENT BRANCH>
+* Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of
+* this software and associated documentation files (the "Software"), to deal in
+* the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+* the Software, and to permit persons to whom the Software is furnished to do so,
+* subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+* FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+* IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* https://www.FreeRTOS.org
+* https://github.com/FreeRTOS
+*
+* 1 tab == 4 spaces!
+*/
+
+/**
+ * @file
+ * @ingroup	ARC_HAL_MISC_TIMER
+ * @brief  implementation of internal timer related functions
+ * @todo RTC support should be improved if RTC is enabled
+ */
+#include "arc/arc_timer.h"
+#include "arc/arc_exception.h"
+
+/**
+ * @brief  check whether the specific timer present
+ * @param[in] no timer number
+ * @return 1 present, 0 not present
+ */
+int32_t arc_timer_present(const uint32_t no)
+{
+    uint32_t bcr = arc_aux_read(AUX_BCR_TIMERS);
+
+    switch (no) {
+      case TIMER_0:
+          bcr = (bcr >> 8) & 1;
+          break;
+
+      case TIMER_1:
+          bcr = (bcr >> 9) & 1;
+          break;
+
+      case RTC_TIMER:
+          bcr = (bcr >> 10) & 1;
+          break;
+
+      case SECURE_TIMER_0:
+          bcr = (bcr >> 11) & 1;
+          break;
+
+      case SECURE_TIMER_1:
+          bcr = (bcr >> 12) & 1;
+          break;
+
+      default:
+          bcr = 0;
+          break;
+    }
+
+    return (int)bcr;
+}
+
+static void arc_timer0_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_TIMER0_LIMIT, val);
+    arc_aux_write(AUX_TIMER0_CTRL, mode);
+    arc_aux_write(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_TIMER1_LIMIT, val);
+    arc_aux_write(AUX_TIMER1_CTRL, mode);
+    arc_aux_write(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_start(const uint32_t mode) {
+    /* Enable with bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Accept A1 & A0 from mode bits 31 & 30 */
+    arc_aux_write(AUX_RTC_CTRL, (mode & 0xC0000003));
+}
+
+static void arc_secure_timer0_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_LIMIT, val);
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, mode);
+    arc_aux_write(AUX_SECURE_TIMER0_CNT, 0);
+}
+
+static void arc_secure_timer1_start(const uint32_t mode, const uint32_t val) {
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_LIMIT, val);
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, mode);
+    arc_aux_write(AUX_SECURE_TIMER1_CNT, 0);
+}
+
+/**
+ * @brief  start the specific timer
+ * @param[in] no	timer number
+ * @param[in] mode	timer mode
+ * @param[in] val	timer limit value (not for RTC)
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint32_t val)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_start(mode, val);
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_start(mode, val);
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_start(mode);
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_start(mode, val);
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_start(mode, val);
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_stop() {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_TIMER0_LIMIT, 0);
+    arc_aux_write(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_stop() {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_TIMER1_LIMIT, 0);
+    arc_aux_write(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_stop() {
+    /* Zero the Enable bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Reserved bits ignored on write, Preserve A1, A0 in bits 31 & 30 */
+    uint32_t mode = arc_aux_read(AUX_RTC_CTRL) & ~0x1;
+    arc_aux_write(AUX_RTC_CTRL, mode);
+}
+
+static void arc_secure_timer0_stop() {
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_LIMIT, 0);
+    arc_aux_write(AUX_SECURE_TIMER0_CNT, 0);
+}
+
+static void arc_secure_timer1_stop() {
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_LIMIT, 0);
+    arc_aux_write(AUX_SECURE_TIMER1_CNT, 0);
+}
+
+/**
+ * @brief  stop and clear the specific timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_stop(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_stop();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_stop();
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_stop();
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_stop();
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_stop();
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER0_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER0_CTRL, val);
+}
+
+static void arc_timer1_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER1_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER1_CTRL, val);
+}
+
+static void arc_secure_timer0_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_SECURE_TIMER0_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_SECURE_TIMER0_CTRL, val);
+}
+
+static void arc_secure_timer1_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_SECURE_TIMER1_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_SECURE_TIMER1_CTRL, val);
+}
+
+/**
+ * @brief  clear the interrupt pending bit of timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_int_clear(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_int_clear();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_int_clear();
+            return 0;
+
+        case SECURE_TIMER_0:
+            arc_secure_timer0_int_clear();
+            return 0;
+
+        case SECURE_TIMER_1:
+            arc_secure_timer1_int_clear();
+            return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  init internal timer
+ */
+void arc_timer_init(void)
+{
+    if (arc_timer_present(TIMER_0)) {
+        arc_timer_stop(TIMER_0);
+    }
+}

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_timer.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arc_timer.h
@@ -1,0 +1,75 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC_TIMER
+ * \brief header file of ARC internal timer
+ */
+
+/**
+ * \addtogroup ARC_HAL_MISC_TIMER
+ * @{
+ */
+
+#ifndef _ARC_HAL_TIMER_H_
+#define _ARC_HAL_TIMER_H_
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+/**
+ * \name arc internal timers names
+ * @{
+ */
+#define TIMER_0         0   /*!< macro name for arc internal timer 0 */
+#define TIMER_1         1   /*!< macro name for arc internal timer 1 */
+#define RTC_TIMER       2   /*!< macro name for arc internal RTC */
+#define SECURE_TIMER_0  3   /*!< macro name for arc internal secure timer 0 */
+#define SECURE_TIMER_1  4   /*!< macro name for arc internal secure timer 1 */
+
+#define INTNO_TIMER0 ARC_FEATURE_TIMER0_VECTOR
+
+/** @} */
+
+/**
+ * \name bit definition of timer CTRL reg
+ * @{
+ */
+#define TIMER_CTRL_IE           (1 << 0)        /*!< Interrupt when count reaches limit */
+#define TIMER_CTRL_NH           (1 << 1)        /*!< Count only when CPU NOT halted */
+#define TIMER_CTRL_W            (1 << 2)        /*!< watchdog enable */
+#define TIMER_CTRL_IP           (1 << 3)        /*!< interrupt pending */
+
+/** @} */
+extern int32_t arc_timer_present(const uint32_t no);
+extern int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint32_t val);
+extern int32_t arc_timer_stop(const uint32_t no);
+extern int32_t arc_timer_int_clear(const uint32_t no);
+extern void arc_timer_init(void);
+
+#endif  /* _ARC_HAL_TIMER_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arconnect.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arconnect.c
@@ -1,0 +1,121 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Implementation of functions defined in arconnect.h
+ */
+
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+#include "arc/arconnect.h"
+
+void arconnect_send_command(uint8_t command, uint16_t parameter)
+{
+    uint32_t cmd = (parameter << 8) | command;
+    arc_aux_write(ARCONNECT_CMD, cmd);
+}
+
+uint32_t arconnect_readback(void)
+{
+    return arc_aux_read(ARCONNECT_READBACK);
+}
+
+void arconnect_send_cmd_check_core_id(void)
+{
+    uint8_t  command   = ARCONNECT_CMD_CHECK_CORE_ID;
+    uint16_t parameter = 0;
+    arconnect_send_command(command, parameter);
+}
+
+void arconnect_send_cmd_intrpt_generate_irq(uint8_t xCoreId)
+{
+    uint8_t  command   = ARCONNECT_CMD_INTRPT_GENERATE_IRQ;
+    uint16_t parameter = xCoreId;
+    arconnect_send_command(command, parameter);
+}
+
+void arconnect_send_cmd_intrpt_generate_ack(uint8_t xCoreId)
+{
+    uint8_t  command   = ARCONNECT_CMD_INTRPT_GENERATE_ACK;
+    uint16_t parameter = xCoreId;
+    arconnect_send_command(command, parameter);
+}
+
+uint32_t arconnect_send_cmd_intrpt_check_source(void)
+{
+    uint8_t  command   = ARCONNECT_CMD_INTRPT_CHECK_SOURCE;
+    uint16_t parameter = 0;
+    arconnect_send_command(command, parameter);
+
+    uint32_t intrpt_source   = 0;
+    uint32_t intrpt_readback = arconnect_readback();
+
+    /* Assume only one core is generating the interrupt */
+    for (int i = 0; i < 32; i++) {
+      if ( intrpt_readback & (1 << i) ) {
+        intrpt_source = i;
+        return intrpt_source;
+      }
+    }
+
+    return intrpt_source;
+}
+
+uint8_t arconnect_send_cmd_intrpt_read_status(uint8_t xCoreId)
+{
+    uint8_t  command   = ARCONNECT_CMD_INTRPT_READ_STATUS;
+    uint16_t parameter = xCoreId;
+    arconnect_send_command(command, parameter);
+
+    uint32_t intrpt_read_status = arconnect_readback();
+    return (intrpt_read_status & 0x01);
+}
+
+uint32_t arconnect_get_core_id(void)
+{
+    arconnect_send_cmd_check_core_id();
+
+    uint32_t readback  = arconnect_readback();
+    uint32_t arcCoreId = (readback & 0x1F);
+
+    return arcCoreId;
+}
+
+arconnect_bcr_t arconnect_get_arconnect_bcr(void)
+{
+    arconnect_bcr_u arconnect_bcr;
+    arconnect_bcr.bits = arc_aux_read(AUX_CONNECT_SYSTEM_BUILD);    
+    return arconnect_bcr.fields;
+}
+
+uint32_t arconnect_get_ici_version(void)
+{
+    uint32_t ici_bcr = arc_aux_read(AUX_CONNECT_ICI_BUILD);
+    uint32_t ici_version = ici_bcr & 0x0FF;
+    return ici_version;
+}

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arconnect.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc/arconnect.h
@@ -1,0 +1,71 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef _ARCONNECT_H_
+#define _ARCONNECT_H_
+
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+typedef struct {
+    /* note: little endian */
+    uint32_t version : 8;   /** The ARConnect version*/
+    uint32_t ext     : 1;   /** Indicates whether ARConnect supports memory-mapped transactions. */
+    uint32_t ici     : 1;   /** Presence of Inter-Core Interrupt Unit */
+    uint32_t ics     : 1;   /** Presence of Inter-Core Semaphore Unit */
+    uint32_t icm     : 1;   /** Presence of Inter-Core Message Unit */
+    uint32_t pmu     : 1;   /** Presence of Power Management Unit */
+    uint32_t icd     : 1;   /** Presence of Inter-Core Debug Unit */
+    uint32_t gfrc    : 1;   /** Presence of Global Free-Running Counter Unit */
+    uint32_t res1    : 1;   /** Reserved */
+    uint32_t corenum : 6;   /** Number of cores (ARC and non-ARC) connected to ARConnect */
+    uint32_t res2    : 1;   /** Reserved */
+    uint32_t idu     : 1;   /** Presence of Interrupt Distribution Unit */
+    uint32_t res3    : 1;   /** Reserved */
+    uint32_t pdm     : 1;   /** Presence of Power Domain Management Unit */
+    uint32_t ivc     : 1;   /** Presence of Interrupt Vector base Control Unit */
+    uint32_t res4    : 5;   /** Reserved */
+} arconnect_bcr_t;
+
+typedef union {
+  arconnect_bcr_t fields;
+  uint32_t        bits;
+} arconnect_bcr_u;
+
+void arconnect_send_command(uint8_t command, uint16_t parameter);
+uint32_t arconnect_readback(void);
+
+void arconnect_send_cmd_check_core_id(void);
+void arconnect_send_cmd_intrpt_generate_irq(uint8_t xCoreId);
+void arconnect_send_cmd_intrpt_generate_ack(uint8_t xCoreId);
+uint32_t arconnect_send_cmd_intrpt_check_source(void);
+uint8_t arconnect_send_cmd_intrpt_read_status(uint8_t xCoreId);
+
+uint32_t arconnect_get_core_id(void);
+arconnect_bcr_t arconnect_get_arconnect_bcr(void);
+uint32_t arconnect_get_ici_version(void);
+
+#endif  /* _ARCONNECT_H_ */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_freertos_exceptions.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_freertos_exceptions.c
@@ -1,0 +1,52 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/**
+ * \file
+ * \brief   exception processing for freertos
+ */
+
+/* #include "embARC.h" */
+
+#include "arc_freertos_exceptions.h"
+
+#ifdef __GNU__
+    extern void gnu_printf_setup( void );
+#endif
+
+/**
+ * \brief  freertos related cpu exception initialization, all the interrupts handled by freertos must be not
+ * fast irqs. If fiq is needed, please install the default firq_exc_entry or your own fast irq entry into
+ * the specific interrupt exception.
+ */
+void freertos_exc_init( void )
+{
+    #ifdef __GNU__
+        gnu_printf_setup();
+    #endif
+}

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_freertos_exceptions.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_freertos_exceptions.h
@@ -1,0 +1,46 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef ARC_FREERTOS_EXCEPTIONS_H
+#define ARC_FREERTOS_EXCEPTIONS_H
+
+/*
+ * here, all arc cpu exceptions share the same entry, also for all interrupt
+ * exceptions
+ */
+extern void exc_entry_cpu( void ); /* cpu exception entry for freertos */
+extern void exc_entry_int( void ); /* int exception entry for freertos */
+
+/* task dispatch functions in .s */
+extern void start_r( void );
+extern void start_dispatch();
+extern void dispatch( void );
+
+extern void freertos_exc_init( void );
+
+#endif /* ARC_FREERTOS_EXCEPTIONS_H */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_support.s
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/arc_support.s
@@ -1,0 +1,566 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/**
+ * \file
+ * \ingroup OS_FREERTOS
+ * \brief  freertos support for arc processor
+ *  like task dispatcher, interrupt handler
+ */
+/** @cond OS_FREERTOS_ASM_ARC_SUPPORT */
+
+/*
+ * core-dependent part in assemble language (for arc)
+ */
+#define __ASSEMBLY__
+#include "arc/arc.h"
+#include "arc/arc_asm_common.h"
+
+/*
+ *  task dispatcher
+ *
+ */
+    .text
+    .align 4
+    .global dispatch
+dispatch:
+/*
+ *  the pre-conditions of this routine are task context, CPU is
+ *  locked, dispatch is enabled.
+ */
+    SAVE_NONSCRATCH_REGS                    /* save callee save registers */
+    mov     r1, dispatch_r
+    PUSH    r1                              /* save return address */
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    bl      dispatcher
+
+/* return routine when task dispatch happened in task context */
+dispatch_r:
+    RESTORE_NONSCRATCH_REGS                 /* recover registers */
+    j       [blink]
+
+/*
+ *  start dispatch
+ */
+    .global start_dispatch
+    .align 4
+start_dispatch:
+/*
+ *  this routine is called in the non-task context during the startup of the kernel
+ *  , and all the interrupts are locked.
+ *
+ *  when the dispatcher is called, the cpu is locked, no nest exception (CPU exception/interrupt).
+ *  In target_initialize, all interrupt priority mask should be cleared, cpu should be
+ *  locked, the interrupts outside the kernel such as fiq can be
+ *  enabled.
+ */
+    clri
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     r1, exc_nest_count
+    add2    r2, r1, r0                      /* r2 = &exc_nest_count[xCoreId] */
+    st      0, [r2]                         /* *r2 = 0 */
+    b       dispatcher_0
+/*
+ *  dispatcher: xCoreId (r0)
+ */
+dispatcher:
+    ld.as   r1, [pxCurrentTCBs, r0]         /* r1 = pxCurrentTCBs[xCoreId] */
+    ld.as   r2, [ulCriticalNesting, r0]     /* r2 = ulCriticalNesting[xCoreId] */
+    PUSH    r2                              /* save critical nesting */
+    st      sp, [r1]                        /* save stack pointer of current task, r1 = pxCurrentTCBs[xCoreId] */
+    jl      vTaskSwitchContext              /* change the value of pxCurrentTCBs[xCoreId] */
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+/*
+ *  before dispatcher is called, task context | cpu locked | dispatch enabled
+ *  should be satisfied. In this routine, the processor will jump
+ *  into the entry of next to run task
+ *
+ *  i.e. kernel mode, IRQ disabled, dispatch enabled
+ *
+ * dispatcher_0: xCoreId (r0)
+ */
+dispatcher_0:
+    ld.as   r1, [pxCurrentTCBs, r0]
+    ld.as   sp, [r1]                        /* recover task stack from pxCurrentTCBs[xCoreId] */
+    mov     r1, r0
+#if ARC_FEATURE_STACK_CHECK
+  #if ARC_FEATURE_SEC_PRESENT
+    lr      r0, [AUX_SEC_STAT]
+    bclr    r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag   r0
+  #else
+    lr      r0, [AUX_STATUS32]
+    bclr    r0, r0, AUX_STATUS_BIT_SC
+    kflag   r0
+  #endif
+    PUSH    r1                              /* save xCoreId */
+    jl      vPortSetStackCheck
+    POP     r1                              /* restore xCoreId */
+  #if ARC_FEATURE_SEC_PRESENT
+    lr      r0, [AUX_SEC_STAT]
+    bset    r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag   r0
+  #else
+    lr      r0, [AUX_STATUS32]
+    bset    r0, r0, AUX_STATUS_BIT_SC
+    kflag   r0
+  #endif
+#endif
+    POP     r0                              /* get critical nesting */
+    mov     r2, ulCriticalNesting
+    add2    r3, r2, r1                      /* r3 = &ulCriticalNesting[xCoreId] */
+    st      r0, [r3]                        /* *r3 = r0 (ulCriticalNesting[xCoreId] = r0) */
+    POP     r0
+    j       [r0]
+
+/*
+ *  task startup routine
+ *
+ */
+    .text
+    .global start_r
+    .align 4
+start_r:
+    seti                                    /* unlock cpu */
+    mov     blink, vPortEndTask             /* set return address */
+    POP     r1                              /* get task function body */
+    POP     r0                              /* get task parameters */
+    j       [r1]
+
+/****** exceptions and interrupts handing ******/
+/****** entry for exception handling ******/
+    .global exc_entry_cpu
+    .align 4
+exc_entry_cpu:
+    EXCEPTION_PROLOGUE
+    mov     r3, sp                          /* as exception handler's para(p_excinfo) */
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     blink, sp
+    mov     r1, exc_nest_count
+    ld.as   r2, [exc_nest_count, r0]        /* r2 = exc_nest_count[xCoreId] */
+    add     r5, r2, 1                       /* r5 = r2 + 1 */
+    add2    r4, r1, r0                      /* r4 = &exc_nest_count[xCoreId] */
+    st      r5, [r4]                        /* *r4 = r5 (exc_nest_count[xCoreId] = r5) */
+    brne    r2, 0, exc_handler_1
+
+exc_handler_1:
+    PUSH    blink
+    lr      r0, [AUX_ECR]
+    lsr     r0, r0, 16
+    mov     r1, exc_int_handler_table
+    ld.as   r2, [r1, r0]
+    mov     r0, r3
+    jl      [r2]                            /* !!!!jump to exception handler where interrupts are not allowed! */
+
+/* interrupts are not allowed */
+ret_exc:
+    POP     sp
+
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     r1, exc_nest_count
+    add2    r3, r1, r0                      /* r3 = &exc_nest_count[xCoreId] */
+    ld      r2, [r3]                        /* r2 = exc_nest_count[xCoreId] */
+    sub     r2, r2, 1                       /* r2-- */
+    st      r2, [r3]                        /* *r3 = r2 (exc_nest_count[xCoreId] = r2) */
+    brne    r2, 0, ret_exc_1                /* nest exception case */
+
+    lr      r1, [AUX_IRQ_ACT]               /* nest interrupt case */
+    brne    r1, 0, ret_exc_1
+
+    ld.as   r1, [context_switch_reqflg, r0] /* r1 = context_switch_reqflg[xCoreId] */
+    brne    r1, 0, ret_exc_2
+
+ret_exc_1:                                  /* return from non-task context, interrupts or exceptions are nested */
+    EXCEPTION_EPILOGUE
+    rtie
+
+/* there is a dispatch request: xCoreId (r0) (from ret_exc) */
+ret_exc_2:
+    /* clear dispatch request */
+    mov     r1, context_switch_reqflg
+    add2    r2, r1, r0                      /* r2 = &context_switch_reqflg[xCoreId] */
+    st      0, [r2]                         /* *r2 = 0 */
+
+    ld.as   r1, [pxCurrentTCBs, r0]         /* r1 = pxCurrentTCBs[xCoreId] */
+    breq    r1, 0, ret_exc_1
+
+    SAVE_CALLEE_REGS    /* save callee save registers */
+
+    lr      r1, [AUX_STATUS32]
+    bclr    r1, r1, AUX_STATUS_BIT_AE       /* clear exception bit */
+    kflag   r1
+
+    mov     r1, ret_exc_r                   /* save return address */
+    PUSH    r1
+
+    /* r0 = xCoreId */
+    bl      dispatcher
+
+ret_exc_r:
+    /* recover exception status */
+    lr      r0, [AUX_STATUS32]
+    bset    r0, r0, AUX_STATUS_BIT_AE
+    kflag   r0
+
+    RESTORE_CALLEE_REGS                     /* recover registers */
+    EXCEPTION_EPILOGUE
+    rtie
+
+/****** entry for normal interrupt exception handling ******/
+    .global exc_entry_int                   /* entry for interrupt handling */
+    .align 4
+exc_entry_int:
+#if ARC_FEATURE_FIRQ == 1
+  #if ARC_FEATURE_RGF_NUM_BANKS > 1
+    lr      r0, [AUX_IRQ_ACT]               /* check whether it is P0 interrupt */
+    btst    r0, 0
+    jnz     exc_entry_firq
+  #else
+    PUSH    r10
+    lr      r10, [AUX_IRQ_ACT]
+    btst    r10, 0
+    POP     r10
+    jnz     exc_entry_firq
+  #endif
+#endif
+    INTERRUPT_PROLOGUE
+    clri                                    /* disable interrupt */
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     blink, sp
+    mov     r1, exc_nest_count
+    add2    r2, r1, r0                      /* r2 = &exc_nest_count[xCoreId] */
+    ld      r3, [r2]                        /* r3 = exc_nest_count[xCoreId] */
+    add     r4, r3, 1                       /* r4 = r3 + 1 */
+    st      r4, [r2]                        /* *r2 = r4 (exc_nest_count[xCoreId] = r4) */
+    seti                                    /* enable higher priority interrupt */
+    brne    r3, 0, irq_handler_1
+
+#if ARC_FEATURE_STACK_CHECK
+  #if ARC_FEATURE_SEC_PRESENT
+    lr      r0, [AUX_SEC_STAT]
+    bclr    r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag   r0
+  #else
+    lr      r0, [AUX_STATUS32]
+    bclr    r0, r0, AUX_STATUS_BIT_SC
+    kflag   r0
+  #endif
+#endif
+
+irq_handler_1:
+    PUSH    blink
+    lr      r0, [AUX_IRQ_CAUSE]
+    mov     r1, exc_int_handler_table
+    ld.as   r2, [r1, r0]                    /* r2 = exc_int_handler_table + irqno *4 */
+/* handle software triggered interrupt */
+    lr      r3, [AUX_IRQ_HINT]
+    cmp     r3, r0
+    bne.d   irq_hint_handled
+    xor     r3, r3, r3
+    sr      r3, [AUX_IRQ_HINT]
+irq_hint_handled:
+    jl      [r2]                            /* jump to interrupt handler */
+
+/* no interrupts are allowed from here */
+ret_int:
+    clri                                    /* disable interrupt */
+    POP     sp
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     r4, r0                          /* r4 = xCoreId */
+    mov     r1, exc_nest_count
+    ld.as   r2, [exc_nest_count, r4]        /* r2 = exc_nest_count[xCoreId] */
+    sub     r2, r2, 1                       /* r2-- */
+    add2    r3, r1, r4                      /* r3 = &exc_nest_count[xCoreId] */
+    st      r2, [r3]                        /* *r3 = r2 (exc_nest_count[xCoreId] = r2) */
+
+/* if there are multi-bits set in IRQ_ACT, it's still in nest interrupt */
+    lr      r0, [AUX_IRQ_CAUSE]
+    sr      r0, [AUX_IRQ_SELECT]
+    lr      r3, [AUX_IRQ_PRIORITY]
+    lr      r1, [AUX_IRQ_ACT]
+    bclr    r2, r1, r3
+    brne    r2, 0, ret_int_1
+
+    ld.as   r0, [context_switch_reqflg, r4] /* r0 = context_switch_reqflg[xCoreId] */
+    brne    r0, 0, ret_int_2
+ret_int_1:  /* return from non-task context */
+    INTERRUPT_EPILOGUE
+    rtie
+/* there is a dispatch request: xCoreId (r4) (from ret_int) */
+ret_int_2:
+    /* clear dispatch request */
+    mov     r0, context_switch_reqflg
+    add2    r3, r0, r4                      /* r3 = &context_switch_reqflg[xCoreId] */
+    st      0, [r3]                         /* *r3 = 0 */
+    ld.as   r0, [pxCurrentTCBs, r4]         /* r0 = pxCurrentTCBs[xCoreId] */
+    breq    r0, 0, ret_int_1
+
+/* r1 has old AUX_IRQ_ACT */
+    PUSH    r1
+/* clear related bits in IRQ_ACT manually to simulate a irq return  */
+    sr      r2, [AUX_IRQ_ACT]
+    SAVE_CALLEE_REGS                        /* save callee save registers */
+    mov     r1, ret_int_r                   /* save return address */
+    PUSH    r1
+    mov     r0, r4                          /* r0 = xCoreId */
+    bl      dispatcher
+
+ret_int_r:
+    RESTORE_CALLEE_REGS                     /* recover registers */
+    POPAX   AUX_IRQ_ACT
+    INTERRUPT_EPILOGUE
+    rtie
+
+#if ARC_FEATURE_FIRQ == 1
+    .global exc_entry_firq
+    .align 4
+exc_entry_firq:
+  #if ARC_FEATURE_STACK_CHECK && ARC_FEATURE_RGF_NUM_BANKS > 1
+    #if ARC_FEATURE_SEC_PRESENT
+    lr      r0, [AUX_SEC_STAT]
+    bclr    r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag   r0
+    #else
+    lr      r0, [AUX_STATUS32]
+    bclr    r0, r0, AUX_STATUS_BIT_SC
+    kflag   r0
+    #endif
+  #endif
+    SAVE_FIQ_EXC_REGS
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     blink, sp
+    mov     r1, exc_nest_count
+    ld.as   r2, [exc_nest_count, r0]        /* r3 = exc_nest_count[xCoreId] */
+    add     r2, r2, 1                       /* r2++ */
+    add2    r3, r1, r0                      /* r3 = &exc_nest_count[xCoreId] */
+    st      r2, [r3]                        /* *r3 = r2  (exc_nest_count[xCoreId] = r2) */
+    brne    r3, 0, firq_handler_1
+
+  #if ARC_FEATURE_STACK_CHECK && ARC_FEATURE_RGF_NUM_BANKS == 1
+    #if ARC_FEATURE_SEC_PRESENT
+    lr      r0, [AUX_SEC_STAT]
+    bclr    r0, r0, AUX_SEC_STAT_BIT_SSC
+    sflag   r0
+    #else
+    lr      r0, [AUX_STATUS32]
+    bclr    r0, r0, AUX_STATUS_BIT_SC
+    kflag   r0
+    #endif
+  #endif
+
+firq_handler_1:
+    PUSH    blink
+    lr      r0, [AUX_IRQ_CAUSE]
+    mov     r1, exc_int_handler_table
+    ld.as   r2, [r1, r0]                    /* r2 = exc_int_handler_table[irqno] */
+/* handle software triggered interrupt */
+    lr      r3, [AUX_IRQ_HINT]
+    brne    r3, r0, firq_hint_handled
+    xor     r3, r3, r3
+    sr      r3, [AUX_IRQ_HINT]
+firq_hint_handled:
+    jl      [r2]                            /* jump to interrupt handler */
+
+/* no interrupts are allowed from here */
+ret_firq:
+    clri
+    POP     sp
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    mov     r4, r0                          /* r4 = xCoreId */
+    mov     r1, exc_nest_count
+    ld.as   r2, [exc_nest_count, r4]        /* r3 = exc_nest_count[xCoreId] */
+    sub     r2, r2, 1                       /* r2-- */
+    add2    r3, r1, r4                      /* r3 = &exc_nest_count[xCoreId] */
+    st      r2, [r3]                        /* *r3 = r2  (exc_nest_count[xCoreId] = r2) */
+
+/* if there are multi-bits set in IRQ_ACT, it's still in nest interrupt */
+    lr      r1, [AUX_IRQ_ACT]
+    bclr    r1, r1, 0
+    brne    r1, 0, ret_firq_1
+
+    ld      r0, [context_switch_reqflg, r4] /* r0 = context_switch_reqflg[xCoreId] */
+    brne    r0, 0, ret_firq_2
+ret_firq_1:                                 /* return from non-task context */
+    RESTORE_FIQ_EXC_REGS
+    rtie
+/* there is a dispatch request: xCoreId (r4) (from ret_firq) */
+ret_firq_2:
+    /* clear dispatch request */
+    mov     r0, context_switch_reqflg
+    add2    r3, r0, r4                      /* r3 = &context_switch_reqflg[xCoreId] */
+    st      0, [r3]                         /* *r3 = 0 */
+    ld.as   r0, [pxCurrentTCBs, r4]         /* r0 = pxCurrentTCBs[xCoreId] */
+    breq    r0, 0, ret_firq_1
+
+/* reconstruct the interruptted context
+ * When ARC_FEATURE_RGF_BANKED_REGS >= 16 (16, 32), sp is banked
+ * so need to restore the fast irq stack.
+ */
+  #if ARC_FEATURE_RGF_BANKED_REGS >= 16
+    RESTORE_LP_REGS
+    #if ARC_FEATURE_CODE_DENSITY
+    RESTORE_CODE_DENSITY
+    #endif
+    RESTORE_R58_R59
+  #endif
+
+/* when BANKED_REGS == 16, r4-r9 wiil be also saved in fast irq stack
+ * so pop them out
+ */
+  #if  ARC_FEATURE_RGF_BANKED_REGS == 16 && !defined(ARC_FEATURE_RF16)
+    POP     r9
+    POP     r8
+    POP     r7
+    POP     r6
+    POP     r5
+    POP     r4
+  #endif
+
+/* for other cases, unbanked regs are already in interrupted context's stack,
+ * so just need to save and pop the banked regs
+ */
+
+/* save the interruptted context */
+  #if ARC_FEATURE_RGF_BANKED_REGS > 0
+/* switch back to bank0  */
+    lr      r0, [AUX_STATUS32]
+    bic     r0, r0, 0x70000
+    kflag   r0
+  #endif
+
+  #if ARC_FEATURE_RGF_BANKED_REGS == 4
+/* r4 - r12, gp, fp, r30, blink already saved */
+    PUSH    r0
+    PUSH    r1
+    PUSH    r2
+    PUSH    r3
+  #elif ARC_FEATURE_RGF_BANKED_REGS == 8
+/* r4 - r9, r0, r11 gp, fp, r30, blink already saved */
+    PUSH    r0
+    PUSH    r1
+    PUSH    r2
+    PUSH    r3
+    PUSH    r12
+  #elif ARC_FEATURE_RGF_BANKED_REGS >= 16
+/* nothing is saved, */
+    SAVE_R0_TO_R12
+
+    SAVE_R58_R59
+    PUSH    gp
+    PUSH    fp
+    PUSH    r30                             /* general purpose */
+    PUSH    blink
+
+    #if ARC_FEATURE_CODE_DENSITY
+    SAVE_CODE_DENSITY
+    #endif
+    SAVE_LP_REGS
+  #endif
+    PUSH    ilink
+    lr      r0, [AUX_STATUS32_P0]
+    PUSH    r0
+    lr      r0, [AUX_IRQ_ACT]
+    PUSH    r0
+    bclr    r0, r0, 0
+    sr      r0, [AUX_IRQ_ACT]
+
+    SAVE_CALLEE_REGS                        /* save callee save registers */
+
+    mov     r1, ret_firq_r                  /* save return address */
+    PUSH    r1
+    bl      arconnect_get_core_id           /* r0 = xCoreId */
+    bl      dispatcher
+
+ret_firq_r:
+    RESTORE_CALLEE_REGS                     /* recover registers */
+    POPAX   AUX_IRQ_ACT
+    POPAX   AUX_STATUS32_P0
+    POP     ilink
+
+  #if ARC_FEATURE_RGF_NUM_BANKS > 1
+    #if ARC_FEATURE_RGF_BANKED_REGS == 4
+/* r4 - r12, gp, fp, r30, blink already saved */
+    POP     r3
+    POP     r2
+    POP     r1
+    POP     r0
+    RESTORE_FIQ_EXC_REGS
+    #elif ARC_FEATURE_RGF_BANKED_REGS == 8
+/* r4 - r9, gp, fp, r30, blink already saved */
+    POP     r12
+    POP     r3
+    POP     r2
+    POP     r1
+    POP     r0
+    RESTORE_FIQ_EXC_REGS
+    #elif ARC_FEATURE_RGF_BANKED_REGS >= 16
+    RESTORE_LP_REGS
+      #if ARC_FEATURE_CODE_DENSITY
+    RESTORE_CODE_DENSITY
+      #endif
+    POP     blink
+    POP     r30
+    POP     fp
+    POP     gp
+
+    RESTORE_R58_R59
+    RESTORE_R0_TO_R12
+    #endif /* ARC_FEATURE_RGF_BANKED_REGS  */
+  #else
+    RESTORE_FIQ_EXC_REGS
+  #endif /* ARC_FEATURE_RGF_NUM_BANKS */
+    rtie
+#endif
+
+/*
+ *  acquire_spin_lock
+ *    r0 = address of spin lock
+ */
+    .text
+    .global acquire_spin_lock
+    .align 4
+acquire_spin_lock:
+    mov     r1, 0x1
+wait_for_release:
+    ex      r1, [r0]
+    cmp     r1, 0
+    bne     wait_for_release
+    nop
+    j       [blink]
+
+/*
+ *  release_spin_lock
+ *    r0 = address of spin lock
+ */
+    .global release_spin_lock
+    .align 4
+release_spin_lock:
+    st      0, [r0]
+    j       [blink]
+
+/** @endcond */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/freertos_tls.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/freertos_tls.c
@@ -1,0 +1,242 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#if defined( __MW__ )
+
+    #include <stdint.h>
+    #include <stdlib.h>
+    #include <string.h>
+
+    #include "FreeRTOS.h"
+
+    #include "queue.h"
+    #include "semphr.h"
+    #include "task.h"
+
+    #include "arc/arc_exception.h"
+    #include "embARC_toolchain.h"
+    #include "embARC_debug.h"
+
+    #ifdef ENABLE_FREERTOS_TLS_DEBUG
+        #define TLS_DEBUG( fmt, ... )    EMBARC_PRINTF( fmt, ## __VA_ARGS__ )
+    #else
+        #define TLS_DEBUG( fmt, ... )
+    #endif
+
+/*
+ * Runtime routines to execute constructors and
+ * destructors for task local storage.
+ */
+    extern void __mw_run_tls_dtor();
+    extern void __mw_run_tls_ctor();
+
+    extern uint32_t exc_nest_count[];
+
+/*
+ * Linker generated symbols to mark .tls section addresses
+ * first byte .. last byte
+ */
+    extern char _ftls[], _etls[];
+    #pragma weak _ftls
+    #pragma weak _etls
+
+    void executable_requires_tls_section( void )
+    {
+        #if _ARC
+            for( ; ; )
+            {
+                _flag( 1 );
+                _nop();
+                _nop();
+                _nop();
+                _nop();
+                _nop();
+            }
+        #endif
+    }
+    #pragma off_inline(executable_requires_tls_section);
+    #pragma alias(executable_requires_tls_section, "executable_requires_.tls_section");
+
+    static void * init_task_tls( void )
+    {
+        uint32_t len = ( uint32_t ) ( _etls - _ftls );
+        void * tls = NULL;
+
+        #if FREERTOS_HEAP_SEL == 3
+        #warning "FreeRTOS TLS support is not compatible with heap 3 solution(FREERTOS_HEAP_SEL=3)!"
+        #warning "You can change FREERTOS_HEAP_SEL in freertos.mk to select other heap solution."
+        #else
+            tls = pvPortMalloc( len );
+        #endif
+
+        if( tls )
+        {
+            TLS_DEBUG( "Malloc task tls:%dbytes\r\n", len );
+            memcpy( tls, _ftls, len );
+            __mw_run_tls_ctor(); /* Run constructors */
+        }
+
+        return tls;
+    }
+
+    static void free_task_tls( void * pxTCB )
+    {
+        TaskHandle_t task2free = ( TaskHandle_t ) pxTCB;
+
+        if( task2free != NULL )
+        {
+            void * tls = pvTaskGetThreadLocalStoragePointer( task2free, 0 );
+
+            if( tls )
+            {
+                TLS_DEBUG( "Free task tls\r\n" );
+                __mw_run_tls_dtor();
+                vPortFree( tls );
+                vTaskSetThreadLocalStoragePointer( task2free, 0, NULL );
+            }
+        }
+    }
+
+    void task_end_hook( void * pxTCB )
+    {
+        free_task_tls( pxTCB );
+    }
+
+    static void * get_isr_tls( void )
+    {
+        /* In an ISR */
+        static int first = 1;
+
+        if( _Rarely( first ) )
+        {
+            first = 0;
+            __mw_run_tls_ctor(); /* Run constructors */
+        }
+
+        return ( void * ) _ftls;
+    }
+    #pragma off_inline(get_isr_tls)
+
+    static void * get_task_tls( void )
+    {
+        TaskHandle_t cur_task;
+
+        cur_task = xTaskGetCurrentTaskHandle();
+
+        if( cur_task == NULL )
+        {
+            return get_isr_tls();
+        }
+
+        void * tls = pvTaskGetThreadLocalStoragePointer( cur_task, 0 );
+
+        if( tls == NULL )
+        {
+            tls = init_task_tls();
+
+            if( tls )
+            {
+                vTaskSetThreadLocalStoragePointer( cur_task, 0, tls );
+            }
+            else
+            {
+                tls = get_isr_tls();
+            }
+        }
+
+        return tls;
+    }
+    #pragma off_inline(get_task_tls)
+
+    #if _ARC /* for ARC XCALLs need to preserve flags */
+        extern void * _Preserve_flags _mwget_tls( void );
+    #endif
+
+/*
+ * Back end gens calls to find local data for this task
+ */
+    void * _mwget_tls( void )
+    {
+        uint32_t arcId = arconnect_get_core_id();
+
+        if( _ftls == ( char * ) 0 )
+        {
+            executable_requires_tls_section();
+        }
+
+        if( exc_nest_count[arcId] > 0 ) /* In ISR */
+        {
+            return get_isr_tls();
+        }
+        else /* In Task */
+        {
+            return get_task_tls();
+        }
+    }
+
+
+/* simple interface of thread safe */
+    typedef xSemaphoreHandle _lock_t;
+    #if configUSE_RECURSIVE_MUTEXES != 1
+        #error "configUSE_RECURSIVE_MUTEXES in FreeRTOSConfig.h need to 1"
+    #endif
+
+    void _mwmutex_create( _lock_t * mutex_ptr )
+    {
+        *mutex_ptr = xSemaphoreCreateRecursiveMutex();
+    }
+
+    void _mwmutex_delete( _lock_t * mutex_ptr )
+    {
+        if( ( *mutex_ptr ) != NULL )
+        {
+            vSemaphoreDelete( *mutex_ptr );
+        }
+    }
+
+    void _mwmutex_lock( _lock_t mutex )
+    {
+        if( ( mutex ) != NULL )
+        {
+            while( xSemaphoreTakeRecursive( mutex, portMAX_DELAY ) != pdTRUE )
+            {
+            }
+        }
+    }
+
+    void _mwmutex_unlock( _lock_t mutex )
+    {
+        if( ( mutex ) != NULL )
+        {
+            xSemaphoreGiveRecursive( mutex );
+        }
+    }
+
+#else /* if defined( __MW__ ) */
+
+#endif /* __MW__ */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/port.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/port.c
@@ -1,0 +1,382 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Implementation of functions defined in portable.h
+ */
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "FreeRTOSConfig.h"
+
+#include "arc/arc_exception.h"
+#include "arc/arc_timer.h"
+#include "arc/arconnect.h"
+#include "board.h"
+
+#include "arc_freertos_exceptions.h"
+
+#include <stdint.h>
+#include <stddef.h>
+#include <stdio.h>
+#include <ctype.h>
+#include <errno.h>
+
+volatile unsigned int ulCriticalNesting[configNUMBER_OF_CORES];
+volatile unsigned int context_switch_reqflg[configNUMBER_OF_CORES]; /* task context switch request flag in exceptions and interrupts handling */
+
+/**
+ * \var exc_nest_count
+ * \brief the counter for exc/int processing, =0 no int/exc
+ * >1 in int/exc processing
+ * @}
+ */
+uint32_t exc_nest_count[configNUMBER_OF_CORES];
+/* --------------------------------------------------------------------------*/
+
+/* acquire_spin_lock and release_spin_lock defined in arc_support.s */
+void acquire_spin_lock(uint32_t *lock);
+void release_spin_lock(uint32_t *lock);
+
+static uint32_t uSpinLocks[portNUM_SPINLOCKS];              /* Locked: uSpinLocks[LOCK_ID] = 1, Unlocked: uSpinLocks[LOCK_ID] = 0 */
+static uint32_t uLockOwner[portNUM_SPINLOCKS];              /* Owned: uSpinLocks[LOCK_ID] = CoreId, Unowned: uSpinLocks[LOCK_ID] = portSPINLOCK_FREE */
+static uint32_t uLockRecursionDepth[portNUM_SPINLOCKS];     /* Must be 0 for a core to take ownership of lock. Increments by 1 each time the owning core acquires the lock, decrements by 1 when released */
+
+/**
+ * @brief kernel tick interrupt handler of freertos
+ */
+/* ----------------------------------------------------------------------------*/
+static void vKernelTick( void * ptr )
+{
+    unsigned int status32;
+    status32 = taskENTER_CRITICAL_FROM_ISR();
+
+    /* clear timer interrupt */
+    arc_timer_int_clear( BOARD_OS_TIMER_ID );
+    board_timer_update( configTICK_RATE_HZ );
+
+    if( xTaskIncrementTick() )
+    {
+        portYIELD_FROM_ISR(); /* need to make task switch */
+    }
+
+    taskEXIT_CRITICAL_FROM_ISR( status32 );
+}
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  setup freertos kernel tick
+ */
+/* ----------------------------------------------------------------------------*/
+static void prvSetupTimerInterrupt( void )
+{
+    unsigned int cyc = configCPU_CLOCK_HZ / configTICK_RATE_HZ;
+
+    int_disable( BOARD_OS_TIMER_INTNO ); /* disable os timer interrupt */
+    arc_timer_stop( BOARD_OS_TIMER_ID );
+    arc_timer_start( BOARD_OS_TIMER_ID, TIMER_CTRL_IE | TIMER_CTRL_NH, cyc );
+
+    int_handler_install( BOARD_OS_TIMER_INTNO, ( INT_HANDLER_T ) vKernelTick );
+    int_pri_set( BOARD_OS_TIMER_INTNO, INT_PRI_MIN );
+    int_enable( BOARD_OS_TIMER_INTNO );
+}
+
+/*
+ * Setup the stack of a new task so it is ready to be placed under the
+ * scheduler control.  The registers have to be placed on the stack in
+ * the order that the port expects to find them.
+ *
+ * For ARC, task context switch is implemented with the help of SWI exception
+ * It's not efficient but simple.
+ *
+ */
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
+{
+    /* To ensure asserts in tasks.c don't fail, although in this case the assert
+     * is not really required. */
+    pxTopOfStack--;
+
+    /* Setup the initial stack of the task.  The stack is set exactly as
+     * expected by the portRESTORE_CONTEXT() macro. */
+
+    /* When the task starts is will expect to find the function parameter in
+     * R0. */
+    *pxTopOfStack = ( StackType_t ) pvParameters; /* R0 */
+
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) pxCode; /* function body */
+
+    /* PC */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) start_r; /* dispatch return address */
+
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) portNO_CRITICAL_NESTING;
+    return pxTopOfStack;
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  start the freertos scheduler, go to the first task
+ *
+ * @returns
+ */
+/* ----------------------------------------------------------------------------*/
+BaseType_t xPortStartScheduler( void )
+{
+    /* Called by vTaskStartScheduler which itself is called by one core only during start-up
+     * Other cores are initiated here by calling vPortYieldCore. This sends an ICI request over
+     * ARConnect to the other core where the interrupt handler will call the dispatcher to
+     * start the first task
+     */
+	uint32_t arcId = arconnect_get_core_id();
+
+    prvSetupTimerInterrupt();
+
+    for (int xCoreID = 0; xCoreID < configNUMBER_OF_CORES; xCoreID++) {
+        if (xCoreID != arcId) {
+	        vPortYieldCore(xCoreID);
+        }
+    }
+
+    start_dispatch();
+
+    /* Should not get here! */
+    return 0;
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortEndScheduler( void )
+{
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  generate a task switch request in ISR
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortYieldFromIsr( void )
+{
+    unsigned int status32;
+
+    status32 = cpu_lock_save();
+	uint32_t arcId = arconnect_get_core_id();
+    context_switch_reqflg[arcId] = true;
+    cpu_unlock_restore( status32 );
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortYield( void )
+{
+    unsigned int status32;
+
+    status32 = cpu_lock_save();
+    dispatch();
+    cpu_unlock_restore( status32 );
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortEndTask( void )
+{
+    #if ( INCLUDE_vTaskDelete == 1 )
+        vTaskDelete( NULL ); /* Delete task itself */
+    #endif
+
+    while( 1 ) /* Yield to other task */
+    {
+        vPortYield();
+    }
+}
+
+/* For SMP */
+void vPortYieldCore( int xCoreID )
+{
+    /* Send IRQ and move on; waiting for ACK causes deadlock */
+	arconnect_send_cmd_intrpt_generate_irq(xCoreID);
+}
+
+void vPortArconnectIciHandler(void *p_excinf)
+{
+    uint32_t srcId = arconnect_send_cmd_intrpt_check_source();
+
+    vPortYieldFromIsr();
+
+    arconnect_send_cmd_intrpt_generate_ack(srcId);
+}
+
+void vPortInitSpinLock( void )
+{
+    for (int lock = 0; lock < portNUM_SPINLOCKS; lock++) {
+        uLockOwner[lock]          = portSPINLOCK_FREE;
+        uLockRecursionDepth[lock] = 0;
+        uSpinLocks[lock]          = 0;
+    }
+}
+
+void vPortGetSpinLock( uint32_t lock )
+{
+    uint32_t arcId = arconnect_get_core_id();
+
+    if (uLockOwner[lock] == arcId) {
+        /* Core already owns the lock, so just increase its recursion depth and return */
+        uLockRecursionDepth[lock]++;
+    } else {
+        /* Core doesn't own the lock, try to acquire it */
+        acquire_spin_lock(&uSpinLocks[lock]);
+        uLockOwner[lock] = arcId;
+        uLockRecursionDepth[lock] = 1;
+    }
+}
+
+void vPortReleaseSpinLock( uint32_t lock )
+{
+    uint32_t arcId = arconnect_get_core_id();
+
+    if ((uLockOwner[lock] == arcId) && (uLockRecursionDepth[lock] != 0)) {
+        /* Decrease recursion depth, reset lock owner, then release spin lock */
+        uLockRecursionDepth[lock]--;
+
+        if (uLockRecursionDepth[lock] == 0) {
+            uLockOwner[lock] = portSPINLOCK_FREE;
+            release_spin_lock(&uSpinLocks[lock]);
+        }
+    }
+}
+/* End For SMP */
+
+#if ARC_FEATURE_STACK_CHECK
+
+/*
+ * !!! Note !!!
+ * This a trick!!!
+ * It's a copy from task.c. We need to konw the definition of TCB for the purpose of hardware
+ * stack check. Pls don't forget to update it when FreeRTOS is updated.
+ */
+    typedef struct tskTaskControlBlock       /* The old naming convention is used to prevent breaking kernel aware debuggers. */
+    {
+        volatile StackType_t * pxTopOfStack; /*< Points to the location of the last item placed on the tasks stack.  THIS MUST BE THE FIRST MEMBER OF THE TCB STRUCT. */
+
+        #if ( portUSING_MPU_WRAPPERS == 1 )
+            xMPU_SETTINGS xMPUSettings; /*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND MEMBER OF THE TCB STRUCT. */
+        #endif
+
+        ListItem_t xStateListItem;                  /*< The list that the state list item of a task is reference from denotes the state of that task (Ready, Blocked, Suspended ). */
+        ListItem_t xEventListItem;                  /*< Used to reference a task from an event list. */
+        UBaseType_t uxPriority;                     /*< The priority of the task.  0 is the lowest priority. */
+        StackType_t * pxStack;                      /*< Points to the start of the stack. */
+        char pcTaskName[ configMAX_TASK_NAME_LEN ]; /*< Descriptive name given to the task when created.  Facilitates debugging only. */ /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+        #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
+            StackType_t * pxEndOfStack; /*< Points to the highest valid address for the stack. */
+        #endif
+
+        #if ( portCRITICAL_NESTING_IN_TCB == 1 )
+            UBaseType_t uxCriticalNesting; /*< Holds the critical section nesting depth for ports that do not maintain their own count in the port layer. */
+        #endif
+
+        #if ( configUSE_TRACE_FACILITY == 1 )
+            UBaseType_t uxTCBNumber;  /*< Stores a number that increments each time a TCB is created.  It allows debuggers to determine when a task has been deleted and then recreated. */
+            UBaseType_t uxTaskNumber; /*< Stores a number specifically for use by third party trace code. */
+        #endif
+
+        #if ( configUSE_MUTEXES == 1 )
+            UBaseType_t uxBasePriority; /*< The priority last assigned to the task - used by the priority inheritance mechanism. */
+            UBaseType_t uxMutexesHeld;
+        #endif
+
+        #if ( configUSE_APPLICATION_TASK_TAG == 1 )
+            TaskHookFunction_t pxTaskTag;
+        #endif
+
+        #if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0 )
+            void * pvThreadLocalStoragePointers[ configNUM_THREAD_LOCAL_STORAGE_POINTERS ];
+        #endif
+
+        #if ( configGENERATE_RUN_TIME_STATS == 1 )
+            uint32_t ulRunTimeCounter; /*< Stores the amount of time the task has spent in the Running state. */
+        #endif
+
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
+            configTLS_BLOCK_TYPE xTLSBlock; /*< Memory block used as Thread Local Storage (TLS) Block for the task. */
+        #endif
+
+        #if ( configUSE_TASK_NOTIFICATIONS == 1 )
+            volatile uint32_t ulNotifiedValue;
+            volatile uint8_t ucNotifyState;
+        #endif
+
+        /* See the comments above the definition of
+         * tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
+        #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 ) /*lint !e731 !e9029 Macro has been consolidated for readability reasons. */
+            uint8_t ucStaticallyAllocated;                     /*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made to free the memory. */
+        #endif
+
+        #if ( INCLUDE_xTaskAbortDelay == 1 )
+            uint8_t ucDelayAborted;
+        #endif
+
+        #if ( configUSE_POSIX_ERRNO == 1 )
+            int iTaskErrno;
+        #endif
+    } tskTCB;
+
+
+    void vPortSetStackCheck( TaskHandle_t old,
+                             TaskHandle_t new )
+    {
+        if( new != NULL )
+        {
+            #if ARC_FEATURE_SEC_PRESENT
+                arc_aux_write( AUX_S_KSTACK_BASE, ( uint32_t ) ( new->pxEndOfStack ) );
+                arc_aux_write( AUX_S_KSTACK_TOP, ( uint32_t ) ( new->pxStack ) );
+            #else
+                arc_aux_write( AUX_KSTACK_BASE, ( uint32_t ) ( new->pxEndOfStack ) );
+                arc_aux_write( AUX_KSTACK_TOP, ( uint32_t ) ( new->pxStack ) );
+            #endif
+        }
+    }
+#endif /* if ARC_FEATURE_STACK_CHECK */

--- a/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/portmacro.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS5x_SMP/portmacro.h
@@ -1,0 +1,184 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2024 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
+#include "FreeRTOS.h"
+
+/* record stack high address for stack check */
+#ifndef configRECORD_STACK_HIGH_ADDRESS
+    #define configRECORD_STACK_HIGH_ADDRESS    1
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR          char
+#define portFLOAT         float
+#define portDOUBLE        double
+#define portLONG          long
+#define portSHORT         short
+#define portSTACK_TYPE    unsigned int
+#define portBASE_TYPE     portLONG
+
+#ifndef Asm
+    #define Asm           __asm__ volatile
+#endif
+
+/*
+ *  normal constants
+ */
+#ifndef NULL
+    #define NULL    0           /* invalid pointer */
+#endif /* NULL */
+
+#ifndef true
+    #define true    1           /* true */
+#endif /* true */
+
+#ifndef false
+    #define false    0          /* false */
+#endif /* false */
+
+typedef portSTACK_TYPE   StackType_t;
+typedef long             BaseType_t;
+typedef unsigned long    UBaseType_t;
+
+#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffff
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
+#else
+    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+#endif
+
+#define portNO_CRITICAL_NESTING    ( ( uint32_t ) 0 )
+#define portSTACK_GROWTH           ( -1 )
+#define portTICK_PERIOD_MS         ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portBYTE_ALIGNMENT         8
+#define portNOP()               Asm( "nop_s" );
+#define IPM_ENABLE_ALL             1
+
+#define portYIELD_FROM_ISR()    vPortYieldFromIsr()
+#define portYIELD()             vPortYield()
+
+/* Critical section management. */
+#define portDISABLE_INTERRUPTS() \
+    {                            \
+        Asm( "clri" );           \
+        Asm( "" ::: "memory" );  \
+    }                            \
+
+#define portENABLE_INTERRUPTS() \
+    {                           \
+        Asm( "" ::: "memory" ); \
+        Asm( "seti" );          \
+    }                           \
+
+extern volatile unsigned int ulCriticalNesting[configNUMBER_OF_CORES];
+
+#define portGET_CRITICAL_NESTING_COUNT()          ( ulCriticalNesting[ portGET_CORE_ID() ] )
+#define portSET_CRITICAL_NESTING_COUNT( x )       ( ulCriticalNesting[ portGET_CORE_ID() ] = ( x ) )
+#define portINCREMENT_CRITICAL_NESTING_COUNT()    ( ulCriticalNesting[ portGET_CORE_ID() ]++ )
+#define portDECREMENT_CRITICAL_NESTING_COUNT()    ( ulCriticalNesting[ portGET_CORE_ID() ]-- )
+
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()              do {} while( 0 )     /* we use the timer */
+#define portALT_GET_RUN_TIME_COUNTER_VALUE( dest )            ( dest = xTickCount )
+
+#if defined( __MW__ )
+    extern void task_end_hook( void * pxTCB );
+    #define portCLEAN_UP_TCB( pxTCB )    task_end_hook( ( void * ) pxTCB )
+#endif
+
+void vPortYield( void );
+void vPortYieldFromIsr( void );
+
+/* For SMP */
+#define portNUM_SPINLOCKS   (2 + configNUM_USER_SPINLOCKS)
+#define portTASK_LOCK_ID    0
+#define portISR_LOCK_ID     1
+#define portSPINLOCK_FREE   0xFFFFFFFF
+
+uint32_t arconnect_get_core_id(void);
+uint32_t cpu_lock_save( void );
+void cpu_unlock_restore( const uint32_t status );
+
+void vPortYieldCore( int xCoreID );
+void vTaskEnterCritical( void );
+void vTaskExitCritical( void );
+UBaseType_t vTaskEnterCriticalFromISR( void );
+void vTaskExitCriticalFromISR( UBaseType_t uxSavedInterruptStatus );
+void vPortInitSpinLock( void );
+void vPortGetSpinLock( uint32_t lock );
+void vPortReleaseSpinLock( uint32_t lock );
+
+void vPortArconnectIciHandler(void *p_excinf);
+
+#define portGET_CORE_ID()                                       arconnect_get_core_id()
+#define portYIELD_CORE( xCoreID )                               vPortYieldCore( (xCoreID) )
+#define portSET_INTERRUPT_MASK()                                cpu_lock_save()
+#define portCLEAR_INTERRUPT_MASK( ulState )                     cpu_unlock_restore( (ulState) )
+#define portSET_INTERRUPT_MASK_FROM_ISR()                       cpu_lock_save()
+#define portCLEAR_INTERRUPT_MASK_FROM_ISR( ulState )            cpu_unlock_restore( (ulState) )
+#define portGET_TASK_LOCK()                                     vPortGetSpinLock( (portTASK_LOCK_ID) )
+#define portRELEASE_TASK_LOCK()                                 vPortReleaseSpinLock( (portTASK_LOCK_ID) )
+#define portGET_ISR_LOCK()                                      vPortGetSpinLock( (portISR_LOCK_ID) )
+#define portRELEASE_ISR_LOCK()                                  vPortReleaseSpinLock( (portISR_LOCK_ID) )
+#define portENTER_CRITICAL()                                    vTaskEnterCritical()
+#define portEXIT_CRITICAL()                                     vTaskExitCritical()
+#define portENTER_CRITICAL_FROM_ISR()                           vTaskEnterCriticalFromISR()
+#define portEXIT_CRITICAL_FROM_ISR( uxSavedInterruptStatus )    vTaskExitCriticalFromISR( (uxSavedInterruptStatus) )
+/* End For SMP */
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
+
+#endif /* PORTMACRO_H */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc.h
@@ -1,0 +1,103 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_CORE_COMM
+ * \brief  header file including common core definitions
+ */
+
+/**
+ * \addtogroup ARC_HAL_CORE_COMM
+ * @{
+ */
+
+#ifndef _ARC_HAL_CORE_H_
+#define _ARC_HAL_CORE_H_
+
+#include "arc_feature_config.h"
+
+#define AUX_BCR_TIMERS                  (0x75)                      /*!< build configuration for processor timers */
+#define AUX_STATUS32                    (0xa)
+#define AUX_STATUS_BIT_AE               (5)                         /*!< processor is in an exception */
+#define AUX_STATUS_BIT_IE               (31)                        /*!< interrupt enable */
+#define AUX_STATUS_BIT_HALT             (0)                         /*!< halt bit */
+#define AUX_STATUS_BIT_SC               (14)                        /*!< stack check bit */
+#define AUX_STATUS_BIT_US               (20)                        /*!< user sleep mode enable bit */
+#define AUX_STATUS_MASK_IE              (1 << AUX_STATUS_BIT_IE)    /*!< mask of AUX_STATUS_BIT_IE */
+#define AUX_STATUS_MASK_HALT            (1 << AUX_STATUS_BIT_HALT)  /*!< mask of AUX_STATUS_BIT_HALT */
+#define AUX_STATUS_MASK_US              (1 << AUX_STATUS_BIT_US)    /*!< mask of AUX_STATUS_BIT_US */
+#define STATUS32_RESET_VALUE            (AUX_STATUS_MASK_US)
+#define AUX_LP_START                    (0x2)                       /*!< loop start address (32-bit) */
+#define AUX_LP_END                      (0x3)                       /*!< loop end address (32-bit) */
+#define AUX_KSTACK_TOP                  (0x264)
+#define AUX_KSTACK_BASE                 (0x265)
+#define AUX_TIMER0_CNT                  (0x21)                      /*!< timer 0 count value */
+#define AUX_TIMER0_CTRL                 (0x22)                      /*!< timer 0 control value */
+#define AUX_TIMER0_LIMIT                (0x23)                      /*!< timer 0 limit value */
+#define AUX_TIMER1_CNT                  (0x100)                     /*!< timer 1 count value */
+#define AUX_TIMER1_CTRL                 (0x101)                     /*!< timer 1 control value */
+#define AUX_TIMER1_LIMIT                (0x102)                     /*!< timer 1 limit value */
+#define AUX_RTC_CTRL                    (0x103)                     /*!< RTC control value */
+#define AUX_RTC_LOW                     (0x104)                     /*!< RTC count low value */
+#define AUX_RTC_HIGH                    (0x105)                     /*!< RTC count high value */
+#define AUX_SECURE_TIMER0_CNT           (0x106)                     /*!< secure timer 0 count value */
+#define AUX_SECURE_TIMER0_CTRL          (0x107)                     /*!< secure timer 0 control value */
+#define AUX_SECURE_TIMER0_LIMIT         (0x108)                     /*!< secure timer 0 limit value */
+#define AUX_SECURE_TIMER1_CNT           (0x109)                     /*!< secure timer 1 count value */
+#define AUX_SECURE_TIMER1_CTRL          (0x10a)                     /*!< secure timer 1 control value */
+#define AUX_SECURE_TIMER1_LIMIT         (0x10b)                     /*!< secure timer 1 limit value */
+#define AUX_ERRET                       (0x400)                     /*!< exception return address */
+#define AUX_ERBTA                       (0x401)                     /*!< BTA saved on exception entry */
+#define AUX_ERSTATUS                    (0x402)                     /*!< STATUS32 saved on exception */
+#define AUX_ECR                         (0x403)                     /*!< exception cause register */
+#define AUX_IRQ_CTRL                    (0xe)                       /*!< interrupt context saving control register */
+#define AUX_INT_VECT_BASE               (0x25)                      /*!< interrupt vector base register */
+#define AUX_IRQ_ACT                     (0x43)                      /*!< active interrupts register */
+#define AUX_IRQ_CAUSE                   (0x40a)                     /*!< interrupt cause register */
+#define AUX_IRQ_SELECT                  (0x40b)                     /*!< interrupt select register */
+#define AUX_IRQ_PRIORITY                (0x206)                     /*!< interrupt priority register */
+#define AUX_IRQ_ENABLE                  (0x40c)                     /*!< interrupt enable register */
+#define AUX_IRQ_TRIGGER                 (0x40d)                     /*!< interrupt trigger: level or pulse */
+#define AUX_IRQ_HINT                    (0x201)                     /*!< software interrupt trigger */
+
+#ifndef __ASSEMBLY__
+
+#include <stdint.h>     /* C99 standard lib */
+#include <limits.h>     /* C99 standard lib */
+#include <stddef.h>     /* C99 standard lib */
+#include <stdbool.h>    /* C99 standard lib */
+
+#define Inline  static __inline__               /* inline function */
+
+#define Asm     __asm__ volatile                /* inline asm (no optimization) */
+
+#endif  /* __ASSEMBLY__ */
+
+#endif  /* _ARC_HAL_CORE_H_ */
+
+// /**  @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_asm_common.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_asm_common.h
@@ -1,0 +1,245 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC
+ * \brief common macro definitions for assembly file
+ */
+/** @cond ARC_HAL_ASM_COMMON */
+
+#ifndef _ARC_HAL_ASM_COMMON_H_
+#define _ARC_HAL_ASM_COMMON_H_
+
+#include "arc/arc.h"
+
+#ifdef __ASSEMBLY__
+/* the assembly macro definitions in ARC GNU and MWDT are
+ * different, so need different processing
+ */
+#if defined(__GNU__)
+#define MACRO_ARG(x) \x
+#define ASM_MACRO1(name, arg1) name arg1
+#else
+#define MACRO_ARG(x) x
+#define ASM_MACRO1(name, arg1) name, arg1
+#endif
+
+/* Note on the LD/ST addr modes with addr reg wback
+ *
+ * LD.a same as LD.aw
+ *
+ * LD.a    reg1, [reg2, x]  => Pre Incr
+ *      Eff Addr for load = [reg2 + x]
+ *
+ * LD.ab   reg1, [reg2, x]  => Post Incr
+ *      Eff Addr for load = [reg2]
+ */
+.macro ASM_MACRO1(PUSHAX, aux)
+	lrl   r10, [MACRO_ARG(aux)]
+	PUSHL r10
+.endm
+
+.macro ASM_MACRO1(POPAX, aux)
+	POPL r10
+	srl  r10, [MACRO_ARG(aux)]
+.endm
+
+/*--------------------------------------------------------------
+ * Helpers to save/restore callee-saved regs:
+ * used by several macros below
+ *-------------------------------------------------------------*/
+.macro SAVE_CALLEE_REGS
+	PUSHL	r13
+	PUSHL	r14
+	PUSHL	r15
+	PUSHL	r16
+	PUSHL	r17
+	PUSHL	r18
+	PUSHL	r19
+	PUSHL	r20
+	PUSHL	r21
+	PUSHL	r22
+	PUSHL	r23
+	PUSHL	r24
+	PUSHL	r25
+.endm
+
+.macro RESTORE_CALLEE_REGS
+	POPL	r25
+	POPL	r24
+	POPL	r23
+	POPL	r22
+	POPL	r21
+	POPL	r20
+	POPL	r19
+	POPL	r18
+	POPL	r17
+	POPL	r16
+	POPL	r15
+	POPL	r14
+	POPL	r13
+.endm
+
+/* macro to save r0 to r12 */
+.macro SAVE_R0_TO_R12
+	PUSHL	r0
+	PUSHL	r1
+	PUSHL	r2
+	PUSHL	r3
+	PUSHL	r4
+	PUSHL	r5
+	PUSHL	r6
+	PUSHL	r7
+	PUSHL	r8
+	PUSHL	r9
+	PUSHL	r10
+	PUSHL	r11
+	PUSHL	r12
+.endm
+
+/* macro to restore r0 to r12 */
+.macro RESTORE_R0_TO_R12
+	POPL	r12
+	POPL	r11
+	POPL	r10
+	POPL	r9
+	POPL	r8
+	POPL	r7
+	POPL	r6
+	POPL	r5
+	POPL	r4
+	POPL	r3
+	POPL	r2
+	POPL	r1
+	POPL	r0
+.endm
+
+/* macro to save all non-caller saved regs */
+.macro SAVE_NONSCRATCH_REGS
+/* caller saved regs are saved by caller function */
+	PUSHL	gp
+	PUSHL	fp
+	PUSHL	blink
+	SAVE_CALLEE_REGS
+.endm
+
+/* macro to restore all non-caller saved regs */
+.macro RESTORE_NONSCRATCH_REGS
+	RESTORE_CALLEE_REGS
+	POPL	blink
+	POPL	fp
+	POPL	gp
+.endm
+
+/* normal interrupt prologue, pc, status and r0-r11 are saved by hardware */
+.macro INTERRUPT_PROLOGUE
+	PUSHL	r12
+	PUSHL	gp
+	PUSHL	fp
+	PUSHL	ilink
+	PUSHL	r30
+
+	subl  sp, sp, 8 /* skip bta */
+.endm
+
+
+/* normal interrupt epilogue, pc, status and r0-r11 are restored by hardware */
+.macro INTERRUPT_EPILOGUE
+	addl  sp, sp, 8 /* skip bta */
+
+	POPL	r30
+	POPL	ilink
+	POPL	fp
+	POPL	gp
+	POPL	r12
+.endm
+
+/* exception prologue, create the same frame of interrupt manually */
+.macro EXCEPTION_PROLOGUE
+	stl.as	r10, [sp, -8]
+	PUSHAX	AUX_ERSTATUS
+	PUSHAX	AUX_ERRET
+
+	PUSHL	blink
+
+	PUSHL	r11
+	subl	sp, sp, 8 /* r10 is  pushed before */
+	PUSHL	r9
+	PUSHL	r8
+	PUSHL	r7
+	PUSHL	r6
+	PUSHL	r5
+	PUSHL	r4
+	PUSHL	r3
+	PUSHL	r2
+	PUSHL	r1
+	PUSHL	r0
+
+	PUSHL	r12
+	PUSHL	gp
+	PUSHL	fp
+	PUSHL	ilink
+	PUSHL	r30
+
+	PUSHAX	AUX_ERBTA
+.endm
+
+/* exception epilogue, restore the same frame of interrupt manually */
+.macro EXCEPTION_EPILOGUE
+	POPAX	AUX_ERBTA
+
+	POPL	r30
+	POPL	ilink
+	POPL	fp
+	POPL	gp
+	POPL	r12
+
+	POPL	r0
+	POPL	r1
+	POPL	r2
+	POPL	r3
+	POPL	r4
+	POPL	r5
+	POPL	r6
+	POPL	r7
+	POPL	r8
+	POPL	r9
+	addl	sp, sp, 8 /* r10 will be popped finally */
+	POPL	r11
+
+	POPL	blink
+
+	POPAX	AUX_ERRET
+	POPAX	AUX_ERSTATUS
+
+	ldl.as	r10, [sp, -8]
+.endm
+
+#endif  /* __ASSEMBLY__ */
+#endif	/* _ARC_HAL_ASM_COMMON_H */
+/** @endcond */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_builtin.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_builtin.h
@@ -1,0 +1,107 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_BUILTIN
+ * @brief Header file of builtin and helper functions
+ *
+ * The Metaware toolchain and the GNU toolchain are supported. The details please go to see the file.
+ */
+
+/**
+ * @addtogroup	ARC_HAL_BUILTIN
+ * @{
+ */
+
+#ifndef _ARC_HAL_BUILTIN_H_
+#define _ARC_HAL_BUILTIN_H_
+
+#include "arc/arc.h"
+
+#ifndef __ASSEMBLY__
+
+#if defined(__CCAC__)
+
+#define arc_aux_read(reg) _lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) _sr((unsigned int)val, (volatile uint32_t)reg)
+
+#define arc_aux_read_long(reg) _lrl((volatile uint64_t)reg)
+#define arc_aux_write_long(reg, val) _srl((unsigned int)val, (volatile uint64_t)reg)
+
+#else /* ! __CCAC__ */
+
+#define arc_aux_read(reg) __builtin_arc_lr((volatile uint32_t)reg)
+#define arc_aux_write(reg, val) __builtin_arc_sr((unsigned int)val, (volatile uint32_t)reg)
+
+#define arc_aux_read_long(reg) __builtin_arc_lrl((volatile uint64_t)reg)
+#define arc_aux_write_long(reg, val) __builtin_arc_srl((unsigned int)val, (volatile uint64_t)reg)
+
+#endif /* __CCAC__ */
+
+/**
+ * @fn void arc_halt(void)
+ * @brief Call kflag instruction to change status32
+ *
+ * @param flag Flag to set in status32
+ */
+Inline void arc_halt(void)
+{
+    /*sr cannot write AUX_STATUS32 */
+    Asm("kflag %0" ::"ir" (1));
+}
+
+/**
+ * @fn uint32_t arc_clri(void)
+ * @brief Call clri instruction
+ * call a clri instruction to disable interrupt
+ * @return interrupt related bits in status32
+ */
+Inline uint32_t arc_clri(void)
+{
+    uint32_t v;
+
+    Asm("clri %0" : "=r" (v):: "memory");
+    return v;
+}
+
+/**
+ * @fn void arc_seti(uint32_t key)
+ * @brief Call seti instruction
+ * call a set instruction to change interrupt status
+ * @param key  interrupt status
+ */
+Inline void arc_seti(uint32_t key)
+{
+    Asm("seti %0" : : "ir" (key) : "memory");
+}
+
+#endif  /* __ASSEMBLY__ */
+
+/** @} */
+#endif /* _ARC_HAL_BUILTIN_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_exception.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_exception.c
@@ -1,0 +1,251 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief C Implementation of exception and interrupt management
+ */
+#include "arc/arc_exception.h"
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ * @var exc_entry_table
+ * @brief exception entry table
+ *
+ * install exception entry table to ARC_AUX_INT_VECT_BASE in startup.
+ * According to ARCv2 ISA, vectors are fetched in instruction space and thus
+ * may be present in ICCM, Instruction Cache, or
+ * main memory accessed by instruction fetch logic.
+ * So it is put into a specific section .vector.
+ *
+ * Please note that the exc_entry_table maybe cached in ARC. Some functions is
+ * defined in .s files.
+ *
+ */
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  default cpu exception handler
+ * @param p_excinf pointer to the exception frame
+ */
+static void exc_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  default interrupt handler
+ * @param[in] p_excinf	information for interrupt handler
+ */
+static void int_handler_default(void *p_excinf)
+{
+    arc_halt();
+}
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_ENTRY_TABLE == 1
+__attribute__ ((aligned(2048), section(".vector")))
+EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL] = {
+    [0] = _arc_reset,
+    [1 ... NUM_EXC_CPU - 1] = exc_entry_cpu,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = exc_entry_int
+};
+#endif
+
+#if ARC_FEATURE_USE_DEFAULT_EXC_INT_HANDLER_TABLE == 1
+/**
+ * @var exc_int_handler_table
+ * @brief the cpu exception and interrupt exception handler table
+ * called in exc_entry_default and exc_entry_int
+ */
+EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL] = {
+    [0 ... NUM_EXC_CPU - 1] = exc_handler_default,
+    [NUM_EXC_CPU ... NUM_EXC_ALL - 1] = int_handler_default
+};
+#endif
+
+typedef struct aux_irq_ctrl_field {
+    /* note: little endian */
+    uint32_t save_nr_gpr_pairs : 5;         /** Indicates number of general-purpose register pairs saved, from 0 to 8/16 */
+    uint32_t res : 4;                       /** Reserved */
+    uint32_t save_blink : 1;                /** Indicates whether to save and restore BLINK */
+    uint32_t save_lp_regs : 1;              /** Indicates whether to save and restore loop registers (LP_COUNT, LP_START, LP_END) */
+    uint32_t save_u_to_u : 1;               /** Indicates if user context is saved to user stack */
+    uint32_t res2 : 1;                      /** Reserved */
+    uint32_t save_idx_regs : 1;             /** Indicates whether to save and restore code-density registers (EI_BASE, JLI_BASE, LDI_BASE) */
+    uint32_t res3 : 18;                     /** Reserved */
+} aux_irq_ctrl_field_t;
+
+typedef union {
+    aux_irq_ctrl_field_t bits;
+    uint32_t value;
+} aux_irq_ctrl_t;
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  initialize the exception and interrupt handling
+ */
+void exc_int_init(void)
+{
+    uint32_t i;
+    uint32_t status;
+    aux_irq_ctrl_t ictrl;
+
+    ictrl.value = 0;
+
+    ictrl.bits.save_nr_gpr_pairs = 6;       /* r0 to r11 (r12 saved manually) */
+
+    ictrl.bits.save_blink = 1;
+    ictrl.bits.save_lp_regs = 1;            /* LP_COUNT, LP_START, LP_END */
+    ictrl.bits.save_u_to_u = 0;             /* user ctxt saved on kernel stack */
+
+    status = arc_lock_save();
+    for (i = NUM_EXC_CPU; i < NUM_EXC_ALL; i++) {
+        /* interrupt level triggered, disabled, priority is the lowest */
+        arc_aux_write(AUX_IRQ_SELECT, i);
+        arc_aux_write(AUX_IRQ_ENABLE, 0);
+        arc_aux_write(AUX_IRQ_TRIGGER, 0);
+        arc_aux_write(AUX_IRQ_PRIORITY, INT_PRI_MAX - INT_PRI_MIN);
+    }
+    arc_aux_write(AUX_IRQ_CTRL, ictrl.value);
+
+    arc_unlock_restore(status);
+
+    /** ipm should be set after cpu unlock restore to avoid reset of the status32 value */
+    arc_int_ipm_set((INT_PRI_MAX - INT_PRI_MIN));
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_CPU
+ * @brief  install an exception handler
+ * @param[in] excno	exception number
+ * @param[in] handler the handler of exception to install
+ */
+/**
+ * warning: only work in simulation and it won't work on any real platform with caches, including
+ * nsim with cache enabled.
+ */
+static int32_t exc_handler_install(const uint32_t excno, EXC_HANDLER_T handler)
+{
+    if (excno < NUM_EXC_ALL && handler != NULL) {
+        exc_int_handler_table[excno] = handler;
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_disable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_disable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+int32_t int_enable(const uint32_t intno)
+{
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        arc_int_enable(intno);
+        return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ * @return  <0 error, 0 ok
+ */
+int32_t int_pri_set(const uint32_t intno, int32_t intpri)
+{
+    uint32_t status;
+
+    if (intno >= NUM_EXC_CPU && intno < NUM_EXC_ALL) {
+        status = cpu_lock_save();
+        intpri = intpri - INT_PRI_MIN;
+        arc_int_pri_set(intno, (uint32_t)intpri);
+        cpu_unlock_restore(status);
+        return 0;
+    }
+    return -1;
+}
+
+/**
+ * @brief  lock cpu and return status
+ *
+ * @returns cpu status
+ */
+uint32_t cpu_lock_save(void)
+{
+    return arc_lock_save();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+void cpu_unlock_restore(const uint32_t status)
+{
+    arc_unlock_restore(status);
+}
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief  install an interrupt handler
+ * @param[in] intno	interrupt number
+ * @param[in] handler interrupt handler to install
+ */
+int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler)
+{
+    /*!< @todo parameter check ? */
+    if (intno >= NUM_EXC_CPU) {
+        return exc_handler_install(intno, handler);
+    }
+
+    return -1;
+}
+
+/** @} end of group ARC_HAL_EXCEPTION_CPU */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_exception.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_exception.h
@@ -1,0 +1,256 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * @file
+ * @ingroup ARC_HAL_EXCEPTION_CPU ARC_HAL_EXCEPTION_INTERRUPT
+ * @brief header file of exception and interrupt management module
+ */
+
+#ifndef _ARC_HAL_EXCEPTION_H_
+#define _ARC_HAL_EXCEPTION_H_
+
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+#ifndef __ASSEMBLY__
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+#ifndef NUM_EXC_CPU
+/*!< number of CPU exceptions */
+#define NUM_EXC_CPU             16
+#endif
+
+/*!< total number of exceptions */
+#define NUM_EXC_ALL             (NUM_EXC_CPU + NUM_EXC_INT)
+
+typedef struct int_exc_frame {
+	uint64_t erbta;
+
+	uint64_t r30;   /* r30 is useless, skipped? */
+	uint64_t ilink; /* r29 is useless, skipped?*/
+	/* r28 is sp, saved other place */
+	uint64_t fp;    /* r27 */
+	uint64_t gp;    /* r26 */
+
+	uint64_t r12;
+	uint64_t r0, r1, r2, r3;
+	uint64_t r4, r5, r6, r7, r8, r9;
+	uint64_t r10, r11;
+	uint64_t blink; /* r31 */
+	uint64_t lp_end, lp_start, lp_count;
+	uint64_t ret;
+	uint64_t status32;
+} __attribute__((packed)) INT_EXC_FRAME_T;
+
+typedef struct callee_frame {
+	uint64_t r25;
+	uint64_t r24;
+	uint64_t r23;
+	uint64_t r22;
+	uint64_t r21;
+	uint64_t r20;
+	uint64_t r19;
+	uint64_t r18;
+	uint64_t r17;
+	uint64_t r16;
+	uint64_t r15;
+	uint64_t r14;
+	uint64_t r13;
+} __attribute__((packed)) CALLEE_FRAME_T;
+
+typedef struct processor_frame {
+	CALLEE_FRAME_T callee_regs;
+	INT_EXC_FRAME_T exc_frame;
+} __attribute__((packed)) PROCESSOR_FRAME_T;
+
+#define ARC_PROCESSOR_FRAME_T_SIZE        (sizeof(PROCESSOR_FRAME_T) / sizeof(uint64_t))
+#define ARC_EXC_FRAME_T_SIZE              (sizeof(INT_EXC_FRAME_T) / sizeof(uint64_t))
+#define ARC_CALLEE_FRAME_T_SIZE           (sizeof(CALLEE_FRAME_T) / sizeof(uint64_t))
+
+extern uint64_t exc_nest_count;
+
+#define INT_PRI_MAX (-1)                /*!< the maximum interrupt priority */
+/**
+ * @brief disable the specific interrupt
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_disable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 0);
+}
+
+/**
+ * @brief  enable the specific int
+ *
+ * @param[in] intno interrupt number
+ */
+Inline void arc_int_enable(const uint32_t intno)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_ENABLE, 1);
+}
+
+/**
+ * @brief  set the interrupt priority mask
+ *
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_ipm_set(uint32_t intpri)
+{
+	volatile uint32_t status;
+
+	status = arc_aux_read(AUX_STATUS32) & ~0x1e;
+
+	status = status | ((intpri << 1) & 0x1e);
+	/* sr cannot write AUX_STATUS32 */
+	Asm("kflag %0" ::"ir" (status));
+}
+
+/**
+ * @brief set interrupt priority
+ *
+ * @param[in] intno interrupt number
+ * @param[in] intpri interrupt priority
+ */
+Inline void arc_int_pri_set(const uint32_t intno, uint32_t intpri)
+{
+	arc_aux_write(AUX_IRQ_SELECT, intno);
+	arc_aux_write(AUX_IRQ_PRIORITY, intpri | (arc_aux_read(AUX_IRQ_PRIORITY) & 0xfffffff0));
+}
+
+/**
+ * @brief  lock cpu, disable interrupts
+ */
+Inline void arc_lock(void)
+{
+	arc_clri();
+}
+
+/**
+ * @brief  unlock cpu, enable interrupts to happen
+ */
+Inline void arc_unlock(void)
+{
+	arc_seti(0);
+}
+
+/**
+ * @brief  lock cpu and status
+ *
+ * @returns cpu status
+ */
+Inline uint32_t arc_lock_save(void)
+{
+	return arc_clri();
+}
+
+/**
+ * @brief  unlock cpu with the specific status
+ *
+ * @param[in] status  cpu status saved by cpu_lock_save
+ */
+Inline void arc_unlock_restore(const uint32_t status)
+{
+	arc_seti(status);
+}
+
+/** @}*/
+
+/**
+ * @addtogroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @typedef EXC_ENTRY_T
+ * @brief  the data type for exception entry
+ */
+typedef void (*EXC_ENTRY_T) (void);
+/**
+ * @typedef EXC_HANDLER_T
+ * @brief  the data type for exception handler
+ */
+typedef void (*EXC_HANDLER_T) (void *exc_frame);
+/** @}*/
+
+/**
+ * @ingroup ARC_HAL_EXCEPTION_INTERRUPT
+ * @typedef INT_HANDLER_T
+ * @brief  the data type for interrupt handler
+ */
+typedef void (*INT_HANDLER_T) (void *ptr);
+
+extern EXC_ENTRY_T exc_entry_table[NUM_EXC_ALL];
+extern EXC_HANDLER_T exc_int_handler_table[NUM_EXC_ALL];
+
+/** @ingroup ARC_HAL_EXCEPTION_CPU
+ * @{
+ */
+/**
+ * @fn _arc_reset
+ * @brief the reset entry
+ */
+extern void _arc_reset(void);
+/**
+ * @fn exc_entry_cpu
+ * @brief the default CPU exception entry
+ */
+extern void exc_entry_cpu(void);
+
+/**
+ * @fn exc_entry_int
+ * @brief the interrupt exception entry
+ */
+extern void exc_entry_int(void);
+/** @}*/
+
+/* exception related APIs */
+extern void exc_int_init(void);
+
+/* interrupt related APIs */
+extern int32_t int_disable(const uint32_t intno);
+extern int32_t int_enable(const uint32_t intno);
+
+/**
+ * @brief  get current interrupt priority mask
+ *
+ * @param[in] intno interrupt number
+ * @return  <0 interrupt priority, 0 error
+ */
+extern int32_t int_pri_set(const uint32_t intno, int32_t intpri);
+extern uint32_t cpu_lock_save(void);
+extern void cpu_unlock_restore(const uint32_t status);
+extern int32_t int_handler_install(const uint32_t intno, INT_HANDLER_T handler);
+
+#endif  /* __ASSEMBLY__ */
+
+#endif /* _ARC_HAL_EXCEPTION_H_*/

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_timer.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_timer.c
@@ -1,0 +1,200 @@
+/*
+* FreeRTOS Kernel V10.6.0
+* Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+*
+* Permission is hereby granted, free of charge, to any person obtaining a copy of
+* this software and associated documentation files (the "Software"), to deal in
+* the Software without restriction, including without limitation the rights to
+* use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+* the Software, and to permit persons to whom the Software is furnished to do so,
+* subject to the following conditions:
+*
+* The above copyright notice and this permission notice shall be included in all
+* copies or substantial portions of the Software.
+*
+* THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+* IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+* FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+* COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+* IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+* CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*
+* https://www.FreeRTOS.org
+* https://github.com/FreeRTOS
+*
+* 1 tab == 4 spaces!
+*/
+
+/**
+ * @file
+ * @ingroup	ARC_HAL_MISC_TIMER
+ * @brief  implementation of internal timer related functions
+ * @todo RTC support should be improved if RTC is enabled
+ */
+#include "arc/arc_timer.h"
+#include "arc/arc_exception.h"
+
+/**
+ * @brief  check whether the specific timer present
+ * @param[in] no timer number
+ * @return 1 present, 0 not present
+ */
+int32_t arc_timer_present(const uint32_t no)
+{
+    uint32_t bcr = arc_aux_read(AUX_BCR_TIMERS);
+
+    switch (no) {
+      case TIMER_0:
+          bcr = (bcr >> 8) & 1;
+          break;
+
+      case TIMER_1:
+          bcr = (bcr >> 9) & 1;
+          break;
+
+      case RTC_TIMER:
+          bcr = (bcr >> 10) & 1;
+          break;
+
+      default:
+          bcr = 0;
+          break;
+    }
+
+    return (int)bcr;
+}
+
+static void arc_timer0_start(const uint32_t mode, const uint64_t val) {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write_long(AUX_TIMER0_LIMIT, val);
+    arc_aux_write(AUX_TIMER0_CTRL, mode);
+    arc_aux_write_long(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_start(const uint32_t mode, const uint64_t val) {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write_long(AUX_TIMER1_LIMIT, val);
+    arc_aux_write(AUX_TIMER1_CTRL, mode);
+    arc_aux_write_long(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_start(const uint32_t mode) {
+    /* Enable with bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Accept A1 & A0 from mode bits 31 & 30 */
+    arc_aux_write(AUX_RTC_CTRL, (mode & 0xC0000003));
+}
+
+/**
+ * @brief  start the specific timer
+ * @param[in] no	timer number
+ * @param[in] mode	timer mode
+ * @param[in] val	timer limit value (not for RTC)
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint64_t val)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_start(mode, val);
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_start(mode, val);
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_start(mode);
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_stop() {
+    arc_aux_write(AUX_TIMER0_CTRL, 0);
+    arc_aux_write_long(AUX_TIMER0_LIMIT, 0);
+    arc_aux_write_long(AUX_TIMER0_CNT, 0);
+}
+
+static void arc_timer1_stop() {
+    arc_aux_write(AUX_TIMER1_CTRL, 0);
+    arc_aux_write_long(AUX_TIMER1_LIMIT, 0);
+    arc_aux_write_long(AUX_TIMER1_CNT, 0);
+}
+
+static void arc_rtc_stop() {
+    /* Zero the Enable bit 0, Clear count registers (AUX_RTC_LOW, AUX_RTC_HIGH) with bit 1, Reserved bits ignored on write, Preserve A1, A0 in bits 31 & 30 */
+    uint32_t mode = arc_aux_read(AUX_RTC_CTRL) & ~0x1;
+    arc_aux_write(AUX_RTC_CTRL, mode);
+}
+
+/**
+ * @brief  stop and clear the specific timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_stop(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_stop();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_stop();
+            return 0;
+
+        case RTC_TIMER:
+            arc_rtc_stop();
+            return 0;
+    }
+
+    return -1;
+}
+
+static void arc_timer0_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER0_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER0_CTRL, val);
+}
+
+static void arc_timer1_int_clear() {
+    uint32_t val;
+
+    val = arc_aux_read(AUX_TIMER1_CTRL);
+    val &= ~TIMER_CTRL_IP;
+    arc_aux_write(AUX_TIMER1_CTRL, val);
+}
+
+/**
+ * @brief  clear the interrupt pending bit of timer
+ *
+ * @param[in] no timer number
+ * @return 0 success, -1 failure
+ */
+int32_t arc_timer_int_clear(const uint32_t no)
+{
+    switch (no) {
+        case TIMER_0:
+            arc_timer0_int_clear();
+            return 0;
+
+        case TIMER_1:
+            arc_timer1_int_clear();
+            return 0;
+    }
+
+    return -1;
+}
+
+/**
+ * @brief  init internal timer
+ */
+void arc_timer_init(void)
+{
+    if (arc_timer_present(TIMER_0)) {
+        arc_timer_stop(TIMER_0);
+    }
+}

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_timer.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc/arc_timer.h
@@ -1,0 +1,73 @@
+/*
+ * FreeRTOS Kernel V10.6.0
+ * Copyright (C) 2023 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ * 1 tab == 4 spaces!
+ */
+
+/**
+ * \file
+ * \ingroup ARC_HAL_MISC_TIMER
+ * \brief header file of ARC internal timer
+ */
+
+/**
+ * \addtogroup ARC_HAL_MISC_TIMER
+ * @{
+ */
+
+#ifndef _ARC_HAL_TIMER_H_
+#define _ARC_HAL_TIMER_H_
+#include "arc/arc.h"
+#include "arc/arc_builtin.h"
+
+/**
+ * \name arc internal timers names
+ * @{
+ */
+#define TIMER_0         0   /*!< macro name for arc internal timer 0 */
+#define TIMER_1         1   /*!< macro name for arc internal timer 1 */
+#define RTC_TIMER       2   /*!< macro name for arc internal RTC */
+
+#define INTNO_TIMER0 ARC_FEATURE_TIMER0_VECTOR
+
+/** @} */
+
+/**
+ * \name bit definition of timer CTRL reg
+ * @{
+ */
+#define TIMER_CTRL_IE           (1 << 0)        /*!< Interrupt when count reaches limit */
+#define TIMER_CTRL_NH           (1 << 1)        /*!< Count only when CPU NOT halted */
+#define TIMER_CTRL_W            (1 << 2)        /*!< watchdog enable */
+#define TIMER_CTRL_IP           (1 << 3)        /*!< interrupt pending */
+
+/** @} */
+extern int32_t arc_timer_present(const uint32_t no);
+extern int32_t arc_timer_start(const uint32_t no, const uint32_t mode, const uint64_t val);
+extern int32_t arc_timer_stop(const uint32_t no);
+extern int32_t arc_timer_int_clear(const uint32_t no);
+extern void arc_timer_init(void);
+
+#endif  /* _ARC_HAL_TIMER_H_ */
+/** @} */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc_freertos_exceptions.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc_freertos_exceptions.c
@@ -1,0 +1,52 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/**
+ * \file
+ * \brief   exception processing for freertos
+ */
+
+/* #include "embARC.h" */
+
+#include "arc_freertos_exceptions.h"
+
+#ifdef __GNU__
+    extern void gnu_printf_setup( void );
+#endif
+
+/**
+ * \brief  freertos related cpu exception initialization, all the interrupts handled by freertos must be not
+ * fast irqs. If fiq is needed, please install the default firq_exc_entry or your own fast irq entry into
+ * the specific interrupt exception.
+ */
+void freertos_exc_init( void )
+{
+    #ifdef __GNU__
+        gnu_printf_setup();
+    #endif
+}

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc_freertos_exceptions.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc_freertos_exceptions.h
@@ -1,0 +1,46 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef ARC_FREERTOS_EXCEPTIONS_H
+#define ARC_FREERTOS_EXCEPTIONS_H
+
+/*
+ * here, all arc cpu exceptions share the same entry, also for all interrupt
+ * exceptions
+ */
+extern void exc_entry_cpu( void ); /* cpu exception entry for freertos */
+extern void exc_entry_int( void ); /* int exception entry for freertos */
+
+/* task dispatch functions in .s */
+extern void start_r( void );
+extern void start_dispatch();
+extern void dispatch();
+
+extern void freertos_exc_init( void );
+
+#endif /* ARC_FREERTOS_EXCEPTIONS_H */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/arc_support.s
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/arc_support.s
@@ -1,0 +1,489 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/**
+ * \file
+ * \ingroup OS_FREERTOS
+ * \brief  freertos support for arc processor
+ *  like task dispatcher, interrupt handler
+ */
+/** @cond OS_FREERTOS_ASM_ARC_SUPPORT */
+
+/*
+ * core-dependent part in assemble language (for arc)
+ */
+#define __ASSEMBLY__
+#include "arc/arc.h"
+#include "arc/arc_asm_common.h"
+
+/*
+ *  task dispatcher
+ *
+ */
+    .text
+    .align 4
+    .global dispatch
+dispatch:
+/*
+ *  the pre-conditions of this routine are task context, CPU is
+ *  locked, dispatch is enabled.
+ */
+    SAVE_NONSCRATCH_REGS    /* save callee save registers */
+    movl  r1, dispatch_r
+    PUSHL r1                 /* save return address */
+    ldl   r0, [pxCurrentTCB]
+    bl    dispatcher
+
+/* return routine when task dispatch happened in task context */
+dispatch_r:
+    RESTORE_NONSCRATCH_REGS /* recover registers */
+    j [blink]
+
+/*
+ *  start dispatch
+ */
+    .global start_dispatch
+    .align 4
+start_dispatch:
+/*
+ *  this routine is called in the non-task context during the startup of the kernel
+ *  , and all the interrupts are locked.
+ *
+ *  when the dispatcher is called, the cpu is locked, no nest exception (CPU exception/interrupt).
+ *  In target_initialize, all interrupt priority mask should be cleared, cpu should be
+ *  locked, the interrupts outside the kernel such as fiq can be
+ *  enabled.
+ */
+    clri
+    movl r0, 0
+    stl  r0, [exc_nest_count]
+    b    dispatcher_0
+/*
+ *  dispatcher
+ */
+dispatcher:
+    ldl   r1, [ulCriticalNesting]
+    PUSHL r1                     /* save critical nesting */
+    stl   sp, [r0]               /* save stack pointer of current task, r0->pxCurrentTCB */
+    jl    vTaskSwitchContext     /* change the value of pxCurrentTCB */
+/*
+ *  before dispatcher is called, task context | cpu locked | dispatch enabled
+ *  should be satisfied. In this routine, the processor will jump
+ *  into the entry of next to run task
+ *
+ *  i.e. kernel mode, IRQ disabled, dispatch enabled
+ */
+dispatcher_0:
+    ldl   r1, [pxCurrentTCB]
+    ldl   sp, [r1]              /* recover task stack */
+#if ARC_FEATURE_STACK_CHECK
+    lrl   r0, [AUX_STATUS32]
+    bclrl r0, r0, AUX_STATUS_BIT_SC
+    kflag r0
+    jl    vPortSetStackCheck
+    lrl   r0, [AUX_STATUS32]
+    bsetl r0, r0, AUX_STATUS_BIT_SC
+    kflag r0
+#endif
+    POPL  r0                        /* get critical nesting */
+    stl   r0, [ulCriticalNesting]
+    POPL  r0                        /* get return address  */
+    j     [r0]
+
+/*
+ *  task startup routine
+ *
+ */
+    .text
+    .global start_r
+    .align 4
+start_r:
+    seti                        /* unlock cpu */
+    movl blink, vPortEndTask    /* set return address */
+    POPL r1                     /* get task function body */
+    POPL r0                     /* get task parameters */
+    j    [r1]
+
+/****** exceptions and interrupts handing ******/
+/****** entry for exception handling ******/
+    .global exc_entry_cpu
+    .align 4
+exc_entry_cpu:
+
+    EXCEPTION_PROLOGUE
+
+    movl   blink,  sp
+    movl   r3, sp                 /* as exception handler's para(p_excinfo) */
+
+    ldl    r0, [exc_nest_count]
+    addl   r1, r0, 1
+    stl    r1, [exc_nest_count]
+    brne   r0, 0, exc_handler_1
+/* change to exception stack if interrupt happened in task context */
+    movl   sp, _e_stack
+exc_handler_1:
+    PUSHL  blink
+
+    lrl    r0, [AUX_ECR]
+    lsr    r0, r0, 16
+    movl   r1, exc_int_handler_table
+    ldl.as r2, [r1, r0]
+
+    movl   r0, r3
+    jl     [r2]                 /* !!!!jump to exception handler where interrupts are not allowed! */
+
+/* interrupts are not allowed */
+ret_exc:
+    POPL sp
+    movl r1, exc_nest_count
+    ldl  r0, [r1]
+    subl r0, r0, 1
+    stl  r0, [r1]
+    brne r0, 0, ret_exc_1       /* nest exception case */
+    lrl  r1, [AUX_IRQ_ACT]      /* nest interrupt case */
+    brne r1, 0, ret_exc_1
+
+    ldl  r0, [context_switch_reqflg]
+    brne r0, 0, ret_exc_2
+ret_exc_1:  /* return from non-task context, interrupts or exceptions are nested */
+
+    EXCEPTION_EPILOGUE
+    rtie
+
+/* there is a dispatch request */
+ret_exc_2:
+    /* clear dispatch request */
+    movl  r0, 0
+    stl   r0, [context_switch_reqflg]
+
+    ldl   r0, [pxCurrentTCB]
+    breq  r0, 0, ret_exc_1
+
+    SAVE_CALLEE_REGS                    /* save callee save registers */
+
+    lrl   r0, [AUX_STATUS32]
+    bclrl r0, r0, AUX_STATUS_BIT_AE     /* clear exception bit */
+    kflag r0
+
+    movl  r1, ret_exc_r                 /* save return address */
+    PUSHL r1
+
+    bl    dispatcher                    /* r0->pxCurrentTCB */
+
+ret_exc_r:
+    /* recover exception status */
+    lrl   r0, [AUX_STATUS32]
+    bsetl r0, r0, AUX_STATUS_BIT_AE
+    kflag r0
+
+    RESTORE_CALLEE_REGS                 /* recover registers */
+    EXCEPTION_EPILOGUE
+    rtie
+
+/****** entry for normal interrupt exception handling ******/
+    .global exc_entry_int   /* entry for interrupt handling */
+    .align 4
+exc_entry_int:
+#if ARC_FEATURE_FIRQ == 1
+#if ARC_FEATURE_RGF_NUM_BANKS > 1
+    lrl   r0, [AUX_IRQ_ACT]              /*  check whether it is P0 interrupt */
+    btstl r0, 0
+    jnz   exc_entry_firq
+#else
+    PUSHL r10
+    lrl   r10, [AUX_IRQ_ACT]
+    btstl r10, 0
+    POPL  r10
+    jnz   exc_entry_firq
+#endif
+#endif
+    INTERRUPT_PROLOGUE
+
+    movl  blink, sp
+
+    clri                                /* disable interrupt */
+    ldl   r3, [exc_nest_count]
+    addl  r2, r3, 1
+    stl   r2, [exc_nest_count]
+    seti                                /* enable higher priority interrupt */
+
+    brne  r3, 0, irq_handler_1
+/* change to exception stack if interrupt happened in task context */
+    movl  sp, _e_stack
+#if ARC_FEATURE_STACK_CHECK
+    lrl   r0, [AUX_STATUS32]
+    bclrl r0, r0, AUX_STATUS_BIT_SC
+    kflag r0
+#endif
+irq_handler_1:
+    PUSHL  blink
+
+    lrl    r0, [AUX_IRQ_CAUSE]
+    movl   r1, exc_int_handler_table
+    ldl.as r2, [r1, r0]                 /* r2 = exc_int_handler_table + irqno *4 */
+/* handle software triggered interrupt */
+    lrl   r3, [AUX_IRQ_HINT]
+    cmpl  r3, r0
+    bne.d irq_hint_handled
+    xorl  r3, r3, r3
+    srl   r3, [AUX_IRQ_HINT]
+irq_hint_handled:
+
+    jl    [r2]                          /* jump to interrupt handler */
+/* no interrupts are allowed from here */
+ret_int:
+    clri                                /* disable interrupt */
+
+    POPL  sp
+    movl  r1, exc_nest_count
+    ldl   r0, [r1]
+    subl  r0, r0, 1
+    stl   r0, [r1]
+/* if there are multi-bits set in IRQ_ACT, it's still in nest interrupt */
+    lrl   r0, [AUX_IRQ_CAUSE]
+    srl   r0, [AUX_IRQ_SELECT]
+    lrl   r3, [AUX_IRQ_PRIORITY]
+    lrl   r1, [AUX_IRQ_ACT]
+    bclrl r2, r1, r3
+    brne  r2, 0, ret_int_1
+
+    ldl   r0, [context_switch_reqflg]
+    brne  r0, 0, ret_int_2
+ret_int_1:  /* return from non-task context */
+    INTERRUPT_EPILOGUE
+    rtie
+/* there is a dispatch request */
+ret_int_2:
+    /* clear dispatch request */
+    movl r0, 0
+    stl  r0, [context_switch_reqflg]
+
+    ldl  r0, [pxCurrentTCB]
+    breq r0, 0, ret_int_1
+
+/* r1 has old AUX_IRQ_ACT */
+    PUSHL r1
+/* clear related bits in IRQ_ACT manually to simulate a irq return  */
+    srl   r2, [AUX_IRQ_ACT]
+
+    SAVE_CALLEE_REGS         /* save callee save registers */
+    movl  r1, ret_int_r      /* save return address */
+    PUSHL r1
+
+    bl  dispatcher  /* r0->pxCurrentTCB */
+
+ret_int_r:
+    RESTORE_CALLEE_REGS     /* recover registers */
+    POPAX AUX_IRQ_ACT
+    INTERRUPT_EPILOGUE
+    rtie
+
+#if ARC_FEATURE_FIRQ == 1
+    .global exc_entry_firq
+    .align 4
+exc_entry_firq:
+#if ARC_FEATURE_STACK_CHECK && ARC_FEATURE_RGF_NUM_BANKS > 1
+    lrl    r0, [AUX_STATUS32]
+    bclrl  r0, r0, AUX_STATUS_BIT_SC
+    kflag  r0
+#endif
+    SAVE_FIQ_EXC_REGS
+
+    movl   blink, sp
+
+    ldl    r3, [exc_nest_count]
+    addl   r2, r3, 1
+    stl    r2, [exc_nest_count]
+
+    brne   r3, 0, firq_handler_1
+#if ARC_FEATURE_STACK_CHECK && ARC_FEATURE_RGF_NUM_BANKS == 1
+    lrl    r0, [AUX_STATUS32]
+    bclrl  r0, r0, AUX_STATUS_BIT_SC
+    kflag  r0
+#endif
+/* change to exception stack if interrupt happened in task context */
+    movl   sp, _e_stack
+firq_handler_1:
+    PUSHL  blink
+
+    lrl    r0, [AUX_IRQ_CAUSE]
+    movl   r1, exc_int_handler_table
+    ldl.as r2, [r1, r0]                     /* r2 = exc_int_handler_table + irqno *4 */
+/* handle software triggered interrupt */
+    lrl    r3, [AUX_IRQ_HINT]
+    brne   r3, r0, firq_hint_handled
+    xorl   r3, r3, r3
+    srl    r3, [AUX_IRQ_HINT]
+firq_hint_handled:
+
+    jl     [r2]                             /* jump to interrupt handler */
+/* no interrupts are allowed from here */
+ret_firq:
+    clri
+    POPL  sp
+
+    movl  r1, exc_nest_count
+    ldl   r0, [r1]
+    subl  r0, r0, 1
+    stl   r0, [r1]
+/* if there are multi-bits set in IRQ_ACT, it's still in nest interrupt */
+    lrl   r1, [AUX_IRQ_ACT]
+    bclrl r1, r1, 0
+    brne  r1, 0, ret_firq_1
+
+    ldl   r0, [context_switch_reqflg]
+    brne  r0, 0, ret_firq_2
+ret_firq_1: /* return from non-task context */
+    RESTORE_FIQ_EXC_REGS
+    rtie
+/* there is a dispatch request */
+ret_firq_2:
+    /* clear dispatch request */
+    movl  r0, 0
+    stl   r0, [context_switch_reqflg]
+
+    ldl   r0, [pxCurrentTCB]
+    breq  r0, 0, ret_firq_1
+
+/* reconstruct the interruptted context
+ * When ARC_FEATURE_RGF_BANKED_REGS >= 16 (16, 32), sp is banked
+ * so need to restore the fast irq stack.
+ */
+#if ARC_FEATURE_RGF_BANKED_REGS >= 16
+#if ARC_FEATURE_CODE_DENSITY
+    RESTORE_CODE_DENSITY
+#endif
+    RESTORE_R58_R59
+#endif
+
+/* when BANKED_REGS == 16, r4-r9 wiil be also saved in fast irq stack
+ * so pop them out
+ */
+#if  ARC_FEATURE_RGF_BANKED_REGS == 16 && !defined(ARC_FEATURE_RF16)
+    POPL    r9
+    POPL    r8
+    POPL    r7
+    POPL    r6
+    POPL    r5
+    POPL    r4
+#endif
+
+/* for other cases, unbanked regs are already in interrupted context's stack,
+ * so just need to save and pop the banked regs
+ */
+
+/* save the interruptted context */
+#if ARC_FEATURE_RGF_BANKED_REGS > 0
+/* switch back to bank0  */
+    lrl   r0, [AUX_STATUS32]
+    bicl  r0, r0, 0x70000
+    kflag r0
+#endif
+
+#if ARC_FEATURE_RGF_BANKED_REGS == 4
+/* r4 - r12, gp, fp, r30, blink already saved */
+    PUSHL    r0
+    PUSHL    r1
+    PUSHL    r2
+    PUSHL    r3
+#elif ARC_FEATURE_RGF_BANKED_REGS == 8
+/* r4 - r9, r0, r11 gp, fp, r30, blink already saved */
+    PUSHL    r0
+    PUSHL    r1
+    PUSHL    r2
+    PUSHL    r3
+    PUSHL    r12
+#elif ARC_FEATURE_RGF_BANKED_REGS >= 16
+/* nothing is saved, */
+    SAVE_R0_TO_R12
+
+    SAVE_R58_R59
+    PUSHL    gp
+    PUSHL    fp
+    PUSHL    r30     /* general purpose */
+    PUSHL    blink
+
+#if ARC_FEATURE_CODE_DENSITY
+    SAVE_CODE_DENSITY
+#endif
+#endif
+    PUSHL  ilink
+    lrl   r0, [AUX_STATUS32_P0]
+    PUSHL  r0
+    lrl   r0, [AUX_IRQ_ACT]
+    PUSHL  r0
+    bclrl r0, r0, 0
+    srl   r0, [AUX_IRQ_ACT]
+
+    SAVE_CALLEE_REGS    /* save callee save registers */
+
+    movl r1, ret_firq_r  /* save return address */
+    PUSHL r1
+    ldl  r0, [pxCurrentTCB]
+    bl   dispatcher  /* r0->pxCurrentTCB */
+
+ret_firq_r:
+    RESTORE_CALLEE_REGS /* recover registers */
+    POPAX   AUX_IRQ_ACT
+    POPAX   AUX_STATUS32_P0
+    POPL    ilink
+
+#if ARC_FEATURE_RGF_NUM_BANKS > 1
+#if ARC_FEATURE_RGF_BANKED_REGS == 4
+/* r4 - r12, gp, fp, r30, blink already saved */
+    POPL r3
+    POPL r2
+    POPL r1
+    POPL r0
+    RESTORE_FIQ_EXC_REGS
+#elif ARC_FEATURE_RGF_BANKED_REGS == 8
+/* r4 - r9, gp, fp, r30, blink already saved */
+    POPL r12
+    POPL r3
+    POPL r2
+    POPL r1
+    POPL r0
+    RESTORE_FIQ_EXC_REGS
+#elif ARC_FEATURE_RGF_BANKED_REGS >= 16
+#if ARC_FEATURE_CODE_DENSITY
+    RESTORE_CODE_DENSITY
+#endif
+    POPL blink
+    POPL r30
+    POPL fp
+    POPL gp
+
+    RESTORE_R58_R59
+    RESTORE_R0_TO_R12
+#endif /* ARC_FEATURE_RGF_BANKED_REGS  */
+#else
+    RESTORE_FIQ_EXC_REGS
+#endif /* ARC_FEATURE_RGF_NUM_BANKS */
+    rtie
+#endif
+/** @endcond */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/freertos_tls.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/freertos_tls.c
@@ -1,0 +1,240 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#if defined( __MW__ )
+
+    #include <stdint.h>
+    #include <stdlib.h>
+    #include <string.h>
+
+    #include "FreeRTOS.h"
+
+    #include "queue.h"
+    #include "semphr.h"
+    #include "task.h"
+
+    #include "arc/arc_exception.h"
+    #include "embARC_toolchain.h"
+    #include "embARC_debug.h"
+
+    #ifdef ENABLE_FREERTOS_TLS_DEBUG
+        #define TLS_DEBUG( fmt, ... )    EMBARC_PRINTF( fmt, ## __VA_ARGS__ )
+    #else
+        #define TLS_DEBUG( fmt, ... )
+    #endif
+
+/*
+ * Runtime routines to execute constructors and
+ * destructors for task local storage.
+ */
+    extern void __mw_run_tls_dtor();
+    extern void __mw_run_tls_ctor();
+
+    extern uint64_t exc_nest_count;
+
+/*
+ * Linker generated symbols to mark .tls section addresses
+ * first byte .. last byte
+ */
+    extern char _ftls[], _etls[];
+    #pragma weak _ftls
+    #pragma weak _etls
+
+    void executable_requires_tls_section( void )
+    {
+        #if _ARC
+            for( ; ; )
+            {
+                _flag( 1 );
+                _nop();
+                _nop();
+                _nop();
+                _nop();
+                _nop();
+            }
+        #endif
+    }
+    #pragma off_inline(executable_requires_tls_section);
+    #pragma alias(executable_requires_tls_section, "executable_requires_.tls_section");
+
+    static void * init_task_tls( void )
+    {
+        uint64_t len = ( uint64_t ) ( _etls - _ftls );
+        void * tls = NULL;
+
+        #if FREERTOS_HEAP_SEL == 3
+        #warning "FreeRTOS TLS support is not compatible with heap 3 solution(FREERTOS_HEAP_SEL=3)!"
+        #warning "You can change FREERTOS_HEAP_SEL in freertos.mk to select other heap solution."
+        #else
+            tls = pvPortMalloc( len );
+        #endif
+
+        if( tls )
+        {
+            TLS_DEBUG( "Malloc task tls:%dbytes\r\n", len );
+            memcpy( tls, _ftls, len );
+            __mw_run_tls_ctor(); /* Run constructors */
+        }
+
+        return tls;
+    }
+
+    static void free_task_tls( void * pxTCB )
+    {
+        TaskHandle_t task2free = ( TaskHandle_t ) pxTCB;
+
+        if( task2free != NULL )
+        {
+            void * tls = pvTaskGetThreadLocalStoragePointer( task2free, 0 );
+
+            if( tls )
+            {
+                TLS_DEBUG( "Free task tls\r\n" );
+                __mw_run_tls_dtor();
+                vPortFree( tls );
+                vTaskSetThreadLocalStoragePointer( task2free, 0, NULL );
+            }
+        }
+    }
+
+    void task_end_hook( void * pxTCB )
+    {
+        free_task_tls( pxTCB );
+    }
+
+    static void * get_isr_tls( void )
+    {
+        /* In an ISR */
+        static int first = 1;
+
+        if( _Rarely( first ) )
+        {
+            first = 0;
+            __mw_run_tls_ctor(); /* Run constructors */
+        }
+
+        return ( void * ) _ftls;
+    }
+    #pragma off_inline(get_isr_tls)
+
+    static void * get_task_tls( void )
+    {
+        TaskHandle_t cur_task;
+
+        cur_task = xTaskGetCurrentTaskHandle();
+
+        if( cur_task == NULL )
+        {
+            return get_isr_tls();
+        }
+
+        void * tls = pvTaskGetThreadLocalStoragePointer( cur_task, 0 );
+
+        if( tls == NULL )
+        {
+            tls = init_task_tls();
+
+            if( tls )
+            {
+                vTaskSetThreadLocalStoragePointer( cur_task, 0, tls );
+            }
+            else
+            {
+                tls = get_isr_tls();
+            }
+        }
+
+        return tls;
+    }
+    #pragma off_inline(get_task_tls)
+
+    #if _ARC /* for ARC XCALLs need to preserve flags */
+        extern void * _Preserve_flags _mwget_tls( void );
+    #endif
+
+/*
+ * Back end gens calls to find local data for this task
+ */
+    void * _mwget_tls( void )
+    {
+        if( _ftls == ( char * ) 0 )
+        {
+            executable_requires_tls_section();
+        }
+
+        if( exc_nest_count > 0 ) /* In ISR */
+        {
+            return get_isr_tls();
+        }
+        else /* In Task */
+        {
+            return get_task_tls();
+        }
+    }
+
+
+/* simple interface of thread safe */
+    typedef xSemaphoreHandle _lock_t;
+    #if configUSE_RECURSIVE_MUTEXES != 1
+        #error "configUSE_RECURSIVE_MUTEXES in FreeRTOSConfig.h need to 1"
+    #endif
+
+    void _mwmutex_create( _lock_t * mutex_ptr )
+    {
+        *mutex_ptr = xSemaphoreCreateRecursiveMutex();
+    }
+
+    void _mwmutex_delete( _lock_t * mutex_ptr )
+    {
+        if( ( *mutex_ptr ) != NULL )
+        {
+            vSemaphoreDelete( *mutex_ptr );
+        }
+    }
+
+    void _mwmutex_lock( _lock_t mutex )
+    {
+        if( ( mutex ) != NULL )
+        {
+            while( xSemaphoreTakeRecursive( mutex, portMAX_DELAY ) != pdTRUE )
+            {
+            }
+        }
+    }
+
+    void _mwmutex_unlock( _lock_t mutex )
+    {
+        if( ( mutex ) != NULL )
+        {
+            xSemaphoreGiveRecursive( mutex );
+        }
+    }
+
+#else /* if defined( __MW__ ) */
+
+#endif /* __MW__ */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/port.c
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/port.c
@@ -1,0 +1,293 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+/*
+ * Implementation of functions defined in portable.h
+ */
+
+#include "FreeRTOS.h"
+#include "task.h"
+#include "FreeRTOSConfig.h"
+
+#include "arc/arc_exception.h"
+#include "arc/arc_timer.h"
+#include "board.h"
+
+#include "arc_freertos_exceptions.h"
+
+volatile unsigned int ulCriticalNesting = 999UL;
+volatile unsigned int context_switch_reqflg; /* task context switch request flag in exceptions and interrupts handling */
+
+/**
+ * \var exc_nest_count
+ * \brief the counter for exc/int processing, =0 no int/exc
+ * >1 in int/exc processing
+ * @}
+ */
+uint64_t exc_nest_count;
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief kernel tick interrupt handler of freertos
+ */
+/* ----------------------------------------------------------------------------*/
+static void vKernelTick( void * ptr )
+{
+    /* clear timer interrupt */
+    arc_timer_int_clear( BOARD_OS_TIMER_ID );
+    board_timer_update( configTICK_RATE_HZ );
+
+    if( xTaskIncrementTick() )
+    {
+        portYIELD_FROM_ISR(); /* need to make task switch */
+    }
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  setup freertos kernel tick
+ */
+/* ----------------------------------------------------------------------------*/
+static void prvSetupTimerInterrupt( void )
+{
+    uint64_t cyc = configCPU_CLOCK_HZ / configTICK_RATE_HZ;
+
+    int_disable( BOARD_OS_TIMER_INTNO ); /* disable os timer interrupt */
+    arc_timer_stop( BOARD_OS_TIMER_ID );
+    arc_timer_start( BOARD_OS_TIMER_ID, TIMER_CTRL_IE | TIMER_CTRL_NH, cyc );
+
+    int_handler_install( BOARD_OS_TIMER_INTNO, ( INT_HANDLER_T ) vKernelTick );
+    int_pri_set( BOARD_OS_TIMER_INTNO, INT_PRI_MIN );
+    int_enable( BOARD_OS_TIMER_INTNO );
+}
+
+/*
+ * Setup the stack of a new task so it is ready to be placed under the
+ * scheduler control.  The registers have to be placed on the stack in
+ * the order that the port expects to find them.
+ *
+ * For ARC, task context switch is implemented with the help of SWI exception
+ * It's not efficient but simple.
+ *
+ */
+StackType_t * pxPortInitialiseStack( StackType_t * pxTopOfStack,
+                                     TaskFunction_t pxCode,
+                                     void * pvParameters )
+{
+    /* To ensure asserts in tasks.c don't fail, although in this case the assert
+     * is not really required. */
+    pxTopOfStack--;
+
+    /* Setup the initial stack of the task.  The stack is set exactly as
+     * expected by the portRESTORE_CONTEXT() macro. */
+
+    /* When the task starts is will expect to find the function parameter in
+     * R0. */
+    *pxTopOfStack = ( StackType_t ) pvParameters; /* R0 */
+
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) pxCode; /* function body */
+
+    /* PC */
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) start_r; /* dispatch return address */
+
+    pxTopOfStack--;
+    *pxTopOfStack = ( StackType_t ) portNO_CRITICAL_NESTING;
+    return pxTopOfStack;
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  start the freertos scheduler, go to the first task
+ *
+ * @returns
+ */
+/* ----------------------------------------------------------------------------*/
+BaseType_t xPortStartScheduler( void )
+{
+    /* Start the timer that generates the tick ISR. */
+    prvSetupTimerInterrupt();
+    start_dispatch();
+
+    /* Should not get here! */
+    return 0;
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortEndScheduler( void )
+{
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief  generate a task switch request in ISR
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortYieldFromIsr( void )
+{
+    unsigned int status32;
+
+    status32 = cpu_lock_save();
+    context_switch_reqflg = true;
+    cpu_unlock_restore( status32 );
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortYield( void )
+{
+    unsigned int status32;
+
+    status32 = cpu_lock_save();
+    dispatch();
+    cpu_unlock_restore( status32 );
+}
+
+/* --------------------------------------------------------------------------*/
+
+/**
+ * @brief
+ */
+/* ----------------------------------------------------------------------------*/
+void vPortEndTask( void )
+{
+    #if ( INCLUDE_vTaskDelete == 1 )
+        vTaskDelete( NULL ); /* Delete task itself */
+    #endif
+
+    while( 1 ) /* Yield to other task */
+    {
+        vPortYield();
+    }
+}
+
+#if ARC_FEATURE_STACK_CHECK
+
+/*
+ * !!! Note !!!
+ * This a trick!!!
+ * It's a copy from task.c. We need to konw the definition of TCB for the purpose of hardware
+ * stack check. Pls don't forget to update it when FreeRTOS is updated.
+ */
+    typedef struct tskTaskControlBlock       /* The old naming convention is used to prevent breaking kernel aware debuggers. */
+    {
+        volatile StackType_t * pxTopOfStack; /*< Points to the location of the last item placed on the tasks stack.  THIS MUST BE THE FIRST MEMBER OF THE TCB STRUCT. */
+
+        #if ( portUSING_MPU_WRAPPERS == 1 )
+            xMPU_SETTINGS xMPUSettings; /*< The MPU settings are defined as part of the port layer.  THIS MUST BE THE SECOND MEMBER OF THE TCB STRUCT. */
+        #endif
+
+        ListItem_t xStateListItem;                  /*< The list that the state list item of a task is reference from denotes the state of that task (Ready, Blocked, Suspended ). */
+        ListItem_t xEventListItem;                  /*< Used to reference a task from an event list. */
+        UBaseType_t uxPriority;                     /*< The priority of the task.  0 is the lowest priority. */
+        StackType_t * pxStack;                      /*< Points to the start of the stack. */
+        char pcTaskName[ configMAX_TASK_NAME_LEN ]; /*< Descriptive name given to the task when created.  Facilitates debugging only. */ /*lint !e971 Unqualified char types are allowed for strings and single characters only. */
+
+        #if ( ( portSTACK_GROWTH > 0 ) || ( configRECORD_STACK_HIGH_ADDRESS == 1 ) )
+            StackType_t * pxEndOfStack; /*< Points to the highest valid address for the stack. */
+        #endif
+
+        #if ( portCRITICAL_NESTING_IN_TCB == 1 )
+            UBaseType_t uxCriticalNesting; /*< Holds the critical section nesting depth for ports that do not maintain their own count in the port layer. */
+        #endif
+
+        #if ( configUSE_TRACE_FACILITY == 1 )
+            UBaseType_t uxTCBNumber;  /*< Stores a number that increments each time a TCB is created.  It allows debuggers to determine when a task has been deleted and then recreated. */
+            UBaseType_t uxTaskNumber; /*< Stores a number specifically for use by third party trace code. */
+        #endif
+
+        #if ( configUSE_MUTEXES == 1 )
+            UBaseType_t uxBasePriority; /*< The priority last assigned to the task - used by the priority inheritance mechanism. */
+            UBaseType_t uxMutexesHeld;
+        #endif
+
+        #if ( configUSE_APPLICATION_TASK_TAG == 1 )
+            TaskHookFunction_t pxTaskTag;
+        #endif
+
+        #if ( configNUM_THREAD_LOCAL_STORAGE_POINTERS > 0 )
+            void * pvThreadLocalStoragePointers[ configNUM_THREAD_LOCAL_STORAGE_POINTERS ];
+        #endif
+
+        #if ( configGENERATE_RUN_TIME_STATS == 1 )
+            uint32_t ulRunTimeCounter; /*< Stores the amount of time the task has spent in the Running state. */
+        #endif
+
+        #if ( configUSE_C_RUNTIME_TLS_SUPPORT == 1 )
+            configTLS_BLOCK_TYPE xTLSBlock; /*< Memory block used as Thread Local Storage (TLS) Block for the task. */
+        #endif
+
+        #if ( configUSE_TASK_NOTIFICATIONS == 1 )
+            volatile uint32_t ulNotifiedValue;
+            volatile uint8_t ucNotifyState;
+        #endif
+
+        /* See the comments above the definition of
+         * tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE. */
+        #if ( tskSTATIC_AND_DYNAMIC_ALLOCATION_POSSIBLE != 0 ) /*lint !e731 !e9029 Macro has been consolidated for readability reasons. */
+            uint8_t ucStaticallyAllocated;                     /*< Set to pdTRUE if the task is a statically allocated to ensure no attempt is made to free the memory. */
+        #endif
+
+        #if ( INCLUDE_xTaskAbortDelay == 1 )
+            uint8_t ucDelayAborted;
+        #endif
+
+        #if ( configUSE_POSIX_ERRNO == 1 )
+            int iTaskErrno;
+        #endif
+    } tskTCB;
+
+
+    void vPortSetStackCheck( TaskHandle_t old,
+                             TaskHandle_t new )
+    {
+        if( new != NULL )
+        {
+            #if ARC_FEATURE_SEC_PRESENT
+                arc_aux_write_long( AUX_S_KSTACK_BASE, ( uint64_t ) ( new->pxEndOfStack ) );
+                arc_aux_write_long( AUX_S_KSTACK_TOP, ( uint64_t ) ( new->pxStack ) );
+            #else
+                arc_aux_write_long( AUX_KSTACK_BASE, ( uint64_t ) ( new->pxEndOfStack ) );
+                arc_aux_write_long( AUX_KSTACK_TOP, ( uint64_t ) ( new->pxStack ) );
+            #endif
+        }
+    }
+#endif /* if ARC_FEATURE_STACK_CHECK */

--- a/portable/ThirdParty/GCC/ARCv3_HS6x/portmacro.h
+++ b/portable/ThirdParty/GCC/ARCv3_HS6x/portmacro.h
@@ -1,0 +1,164 @@
+/*
+ * FreeRTOS Kernel <DEVELOPMENT BRANCH>
+ * Copyright (C) 2020 Synopsys, Inc. or its affiliates.  All Rights Reserved.
+ *
+ * SPDX-License-Identifier: MIT
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ *
+ * https://www.FreeRTOS.org
+ * https://github.com/FreeRTOS
+ *
+ */
+
+#ifndef PORTMACRO_H
+#define PORTMACRO_H
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    extern "C" {
+#endif
+/* *INDENT-ON* */
+
+/* record stack high address for stack check */
+#ifndef configRECORD_STACK_HIGH_ADDRESS
+    #define configRECORD_STACK_HIGH_ADDRESS    1
+#endif
+
+/*-----------------------------------------------------------
+ * Port specific definitions.
+ *
+ * The settings in this file configure FreeRTOS correctly for the
+ * given hardware and compiler.
+ *
+ * These settings should not be altered.
+ *-----------------------------------------------------------
+ */
+
+/* Type definitions. */
+#define portCHAR                char
+#define portFLOAT               float
+#define portDOUBLE              double
+#define portLONG                long
+#define portSHORT               short
+#define portSTACK_TYPE          unsigned long long int
+#define portBASE_TYPE           portLONG
+#define portPOINTER_SIZE_TYPE   unsigned long long int
+
+#ifndef Asm
+    #define Asm           __asm__ volatile
+#endif
+
+/*
+ *  normal constants
+ */
+#ifndef NULL
+    #define NULL    0           /* invalid pointer */
+#endif /* NULL */
+
+#ifndef true
+    #define true    1           /* true */
+#endif /* true */
+
+#ifndef false
+    #define false    0          /* false */
+#endif /* false */
+
+typedef portSTACK_TYPE   StackType_t;
+typedef long             BaseType_t;
+typedef unsigned long    UBaseType_t;
+
+#if ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_16_BITS )
+    typedef uint16_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffff
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_32_BITS )
+    typedef uint32_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffffffffUL
+#elif ( configTICK_TYPE_WIDTH_IN_BITS == TICK_TYPE_WIDTH_64_BITS )
+    typedef uint64_t     TickType_t;
+    #define portMAX_DELAY    ( TickType_t ) 0xffffffffffffffffULL
+#else
+    #error configTICK_TYPE_WIDTH_IN_BITS set to unsupported tick type width.
+#endif
+
+#define portNO_CRITICAL_NESTING    ( ( uint32_t ) 0 )
+#define portSTACK_GROWTH           ( -1 )
+#define portTICK_PERIOD_MS         ( ( TickType_t ) 1000 / configTICK_RATE_HZ )
+#define portBYTE_ALIGNMENT         8
+#define portNOP()               Asm( "nop_s" );
+#define IPM_ENABLE_ALL             1
+
+#define portYIELD_FROM_ISR()    vPortYieldFromIsr()
+#define portYIELD()             vPortYield()
+
+/* Critical section management. */
+#define portDISABLE_INTERRUPTS() \
+    {                            \
+        Asm( "clri" );           \
+        Asm( "" ::: "memory" );  \
+    }                            \
+
+#define portENABLE_INTERRUPTS() \
+    {                           \
+        Asm( "" ::: "memory" ); \
+        Asm( "seti" );          \
+    }                           \
+
+extern volatile unsigned int ulCriticalNesting;
+
+#define portENTER_CRITICAL()     \
+    {                            \
+        portDISABLE_INTERRUPTS() \
+        ulCriticalNesting++;     \
+    }
+
+
+#define portEXIT_CRITICAL()                                    \
+    {                                                          \
+        if( ulCriticalNesting > portNO_CRITICAL_NESTING )      \
+        {                                                      \
+            ulCriticalNesting--;                               \
+            if( ulCriticalNesting == portNO_CRITICAL_NESTING ) \
+            {                                                  \
+                portENABLE_INTERRUPTS()                        \
+            }                                                  \
+        }                                                      \
+    }
+
+
+#define portTASK_FUNCTION_PROTO( vFunction, pvParameters )    void vFunction( void * pvParameters )
+#define portTASK_FUNCTION( vFunction, pvParameters )          void vFunction( void * pvParameters )
+
+#define portCONFIGURE_TIMER_FOR_RUN_TIME_STATS()              do {} while( 0 )     /* we use the timer */
+#define portALT_GET_RUN_TIME_COUNTER_VALUE( dest )            ( dest = xTickCount )
+
+#if defined( __MW__ )
+    extern void task_end_hook( void * pxTCB );
+    #define portCLEAN_UP_TCB( pxTCB )    task_end_hook( ( void * ) pxTCB )
+#endif
+
+void vPortYield( void );
+void vPortYieldFromIsr( void );
+
+/* *INDENT-OFF* */
+#ifdef __cplusplus
+    }
+#endif
+/* *INDENT-ON* */
+
+#endif /* PORTMACRO_H */


### PR DESCRIPTION
Port ARC: Common components of the ARC Demo and a fix for hardware stack checking
Includes port to support ARCv3 HS6x and SMP-mode for ARCv3 HS5x

Siyuan Cheng's ARC Demo: https://github.com/SiyuanCheng-CN/FreeRTOS/pull/1
Yuguo Zou's fix for hardware stack checking: https://github.com/foss-for-synopsys-dwc-arc-processors/FreeRTOS-Kernel/commit/af5a9459a8b63112cbb5c8609a89d94848a3cb59